### PR TITLE
Setup/backend postgres implement

### DIFF
--- a/aspnet-core/src/JourneyPoint.Web.Host/appsettings.json
+++ b/aspnet-core/src/JourneyPoint.Web.Host/appsettings.json
@@ -5,7 +5,7 @@
   "App": {
     "ServerRootAddress": "https://localhost:44311/",
     "ClientRootAddress": "http://localhost:4200/",
-    "CorsOrigins": "http://localhost:4200,http://localhost:8080,http://localhost:8081,http://localhost:3000"
+    "CorsOrigins": "http://localhost:4200,http://localhost:8080,http://localhost:8081,http://localhost:3000,https://journeypointbackend.onrender.com"
   },
   "Authentication": {
     "JwtBearer": {


### PR DESCRIPTION
Linking Issue: #2, Linking PR's: #3 #4 

Removed the Kestrel server configuration section, including the HTTP endpoint for "https://localhost:44311/", from appsettings.json to streamline server settings management.