### PR TITLE
Fix tenantId handling and improve cookie management in setTenantCookie

### DIFF
--- a/aspnet-core/src/JourneyPoint.Web.Host/wwwroot/swagger/ui/abp.swagger.js
+++ b/aspnet-core/src/JourneyPoint.Web.Host/wwwroot/swagger/ui/abp.swagger.js
@@ -33,6 +33,14 @@ var abp = abp || {};
         }
     }
 
+    function setTenantCookie(tenantId) {
+        if (tenantId) {
+            document.cookie = 'Abp.TenantId=' + encodeURIComponent(tenantId) + '; path=/';
+            return;
+        }
+        document.cookie = 'Abp.TenantId=; path=/; max-age=0';
+    }
+
     function loginUserInternal(tenantId, callback) {
         var usernameOrEmailAddress = document.getElementById('userName').value;
         if (!usernameOrEmailAddress) {
@@ -62,6 +70,7 @@ var abp = abp || {};
             }
         };
 
+        setTenantCookie(tenantId);
         xhr.open('POST', '/api/TokenAuth/Authenticate', true);
         xhr.setRequestHeader('Abp.TenantId', tenantId);
         xhr.setRequestHeader('Content-type', 'application/json');


### PR DESCRIPTION
Linking Issue: #2, Linking PR's: #3 #4 #5 

This pull request adds functionality to manage the tenant cookie when authenticating users in the Swagger UI JavaScript code. The main change is the introduction of a helper function to set or clear the `Abp.TenantId` cookie based on the provided tenant ID, which is now called during the login process.

Tenant cookie management:

* Added a `setTenantCookie` function to set or clear the `Abp.TenantId` cookie depending on whether a tenant ID is provided. (`aspnet-core/src/JourneyPoint.Web.Host/wwwroot/swagger/ui/abp.swagger.js`)
* Updated the `loginUserInternal` function to call `setTenantCookie` with the current tenant ID before sending the authentication request, ensuring the cookie is properly set for the session. (`aspnet-core/src/JourneyPoint.Web.Host/wwwroot/swagger/ui/abp.swagger.js`)