### PR TITLE
fix: correct tenantId constant and header format in axios instance

### DIFF
--- a/journeypoint/constants/auth/cookies.ts
+++ b/journeypoint/constants/auth/cookies.ts
@@ -1,6 +1,6 @@
 export const AUTH_COOKIE_NAMES = {
   token: "token",
-  tenantId: "tenantId",
+  tenantId: "Abp.TenantId",
   tenancyName: "tenancyName",
   tenantName: "tenantName",
 };

--- a/journeypoint/utils/axiosInstance.tsx
+++ b/journeypoint/utils/axiosInstance.tsx
@@ -11,7 +11,7 @@ export const getAxiosInstace = () => {
         headers: {
             "Content-Type": "application/json",
             ...(token ? { Authorization: `Bearer ${token}` } : {}),
-            ...(tenantId ? { "Abp-TenantId": tenantId } : {}),
+            ...(tenantId ? { "Abp.TenantId": tenantId } : {}),
         },
     });
 };


### PR DESCRIPTION
Linking Issues: #8 , Linking PR's: #9  

This pull request updates the way tenant IDs are handled in authentication and API requests to ensure consistency with expected naming conventions. The main change is renaming the tenant ID cookie and corresponding HTTP header to use the correct format.

**Authentication and API request updates:**

* Changed the `tenantId` key in `AUTH_COOKIE_NAMES` from `"tenantId"` to `"Abp.TenantId"` to match the expected cookie name.
* Updated the Axios instance to send the tenant ID in the `"Abp.TenantId"` header instead of `"Abp-TenantId"`, ensuring compatibility with backend expectations.