### PR TITLE
fix: reorder ABP initialization in Configure method for consistency

### DIFF
--- a/aspnet-core/src/JourneyPoint.Web.Host/Startup/Startup.cs
+++ b/aspnet-core/src/JourneyPoint.Web.Host/Startup/Startup.cs
@@ -83,9 +83,9 @@ namespace JourneyPoint.Web.Host.Startup
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
-            app.UseAbp(options => { options.UseAbpRequestLocalization = false; }); // Initializes ABP framework.
-
             app.UseCors(_defaultCorsPolicyName); // Enable CORS!
+
+            app.UseAbp(options => { options.UseAbpRequestLocalization = false; }); // Initializes ABP framework.
 
             app.UseStaticFiles();
 


### PR DESCRIPTION
Linking Issues: #8 , Linking PR's: #9 #10  

This pull request makes a minor change to the startup configuration order in `Startup.cs`. The initialization of the ABP framework with `app.UseAbp` has been moved to occur after CORS is enabled, which may help avoid issues related to request localization or middleware ordering.

- Middleware ordering:
  * Moved `app.UseAbp` to occur after `app.UseCors` in `Startup.cs` to ensure proper initialization sequence.