### PR TITLE
Implement multi-tenant proxy API and update Axios base URL

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,29 @@
       "Bash(find 'c:/Users/Hashim/Documents/Git Repos/JourneyPoint/angular' -type f -name *.ts -not -path */node_modules/* -not -path */.angular/* -not -path *dist/*)",
       "Bash(find 'c:/Users/Hashim/Documents/Git Repos/JourneyPoint/journeypoint' -type f -name *.tsx -not -path */node_modules/* -not -path */.next/*)",
       "Bash(find 'c:/Users/Hashim/Documents/Git Repos/JourneyPoint/journeypoint' -type f -not -path */node_modules/* -not -path */.next/*)",
-      "Bash(grep -r \"TenantId\\\\|tenantid\\\\|Abp-TenantId\\\\|Abp.TenantId\" 'c:/Users/Hashim/Documents/Git Repos/JourneyPoint/journeypoint' --include=*.ts --include=*.tsx -l)"
+      "Bash(grep -r \"TenantId\\\\|tenantid\\\\|Abp-TenantId\\\\|Abp.TenantId\" 'c:/Users/Hashim/Documents/Git Repos/JourneyPoint/journeypoint' --include=*.ts --include=*.tsx -l)",
+      "Bash(grep -r \"HttpTenantResolveContributor\\\\|ITenantResolveContributor\\\\|TenantResolveContributor\" 'c:/Users/Hashim/Documents/Git Repos/JourneyPoint/aspnet-core' --include=*.cs -l)",
+      "Bash(find 'c:/Users/Hashim/Documents/Git Repos/JourneyPoint/aspnet-core' -path */Abp.AspNetCore* -name *.dll)",
+      "Read(//c/Users/Hashim/.nuget/**)",
+      "Bash(xargs grep:*)",
+      "Bash(find /c/Users/Hashim/.nuget -name *.cs)",
+      "Bash(find /c/Users/Hashim/.nuget/packages/abp.aspnetcore/9.4.1 -name *.cs)",
+      "Bash(find /c/Users/Hashim/.nuget/packages/abp.aspnetcore/9.4.1 -name *.dll)",
+      "Bash(powershell -Command \"& { Add-Type -Path ''''Abp.AspNetCore.dll''''; [System.Reflection.Assembly]::LoadFrom\\(\\(Resolve-Path ''''Abp.AspNetCore.dll''''\\).Path\\).GetTypes\\(\\) | Where-Object { $_ame -match ''''Tenant'''' } | Select-Object FullName }\")",
+      "Bash(powershell -Command \"[System.Reflection.Assembly]::LoadFrom\\(''C:/Users/Hashim/.nuget/packages/abp.aspnetcore/9.4.1/lib/net8.0/Abp.AspNetCore.dll''\\).GetTypes\\(\\) | Where-Object { $_.Name -match ''Tenant'' } | Select-Object -ExpandProperty FullName\")",
+      "Bash(cd /tmp)",
+      "Bash(cp /c/Users/Hashim/.nuget/packages/abp.aspnetcore/9.4.1/abp.aspnetcore.9.4.1.nupkg abp.zip)",
+      "Bash(unzip -o abp.zip *.cs -d abp_src)",
+      "Bash(find abp_src -name *.cs)",
+      "WebSearch",
+      "WebFetch(domain:aspnetboilerplate.com)",
+      "WebFetch(domain:github.com)",
+      "Bash(powershell -Command \":*)",
+      "Bash(cd /c/Users/Hashim/Documents/Git Repos/JourneyPoint/journeypoint)",
+      "Read(//c/Users/Hashim/Documents/Git/ Repos/JourneyPoint/journeypoint/utils/**)",
+      "Bash(gh api:*)",
+      "Bash(python3 -c \"import json,sys; [print\\(f[''''path'''']\\) for f in json.load\\(sys.stdin\\) if f[''''type'''']==''''dir'''' or f[''''name''''].endswith\\(\\(''''.ts'''',''''.tsx'''',''''.js'''',''''.json''''\\)\\)]\")",
+      "Bash(python3 -c \"import json,sys; [print\\(f[''''path'''']\\) for f in json.load\\(sys.stdin\\)]\")"
     ]
   }
 }

--- a/journeypoint/app/api/proxy/[...path]/route.ts
+++ b/journeypoint/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL = (process.env.API_BACKEND_URL ?? "").replace(/\/$/, "");
+
+const getTenantId = (request: NextRequest): string | null =>
+    request.headers.get("abp.tenantid") ??
+    request.headers.get("Abp.TenantId") ??
+    request.cookies.get("Abp.TenantId")?.value ??
+    null;
+
+async function handleRequest(
+    request: NextRequest,
+    context: { params: Promise<{ path: string[] }> }
+) {
+    const { path } = await context.params;
+    const search = request.nextUrl.search ?? "";
+    const targetUrl = `${BACKEND_URL}/${path.join("/")}${search}`;
+    const tenantId = getTenantId(request);
+
+    const body =
+        request.method === "GET" || request.method === "HEAD"
+            ? undefined
+            : await request.text();
+
+    try {
+        const response = await fetch(targetUrl, {
+            method: request.method,
+            headers: {
+                "Content-Type": request.headers.get("content-type") ?? "application/json",
+                ...(request.headers.get("authorization")
+                    ? { Authorization: request.headers.get("authorization")! }
+                    : {}),
+                ...(tenantId
+                    ? {
+                        "Abp.TenantId": tenantId,
+                        Cookie: `Abp.TenantId=${encodeURIComponent(tenantId)}`,
+                    }
+                    : {}),
+            },
+            body,
+        });
+
+        const responseBody = await response.arrayBuffer();
+
+        return new NextResponse(responseBody, {
+            status: response.status,
+            headers: {
+                "Content-Type": response.headers.get("content-type") ?? "application/json",
+            },
+        });
+    } catch (error) {
+        console.error(`[proxy] ${request.method} ${targetUrl} failed:`, error);
+        return NextResponse.json(
+            { error: "Proxy request failed", detail: String(error) },
+            { status: 502 }
+        );
+    }
+}
+
+export async function GET(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+    return handleRequest(request, context);
+}
+
+export async function POST(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+    return handleRequest(request, context);
+}
+
+export async function PUT(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+    return handleRequest(request, context);
+}
+
+export async function DELETE(request: NextRequest, context: { params: Promise<{ path: string[] }> }) {
+    return handleRequest(request, context);
+}
+
+export async function OPTIONS() {
+    return new NextResponse(null, { status: 204 });
+}

--- a/journeypoint/helpers/useAppSession.tsx
+++ b/journeypoint/helpers/useAppSession.tsx
@@ -23,16 +23,21 @@ export const useAppSession = () => {
   const [configurationError, setConfigurationError] = useState<string | null>(null);
   const getMeRef = useRef(authActions.getMe);
   const resolveTenantRef = useRef(authActions.resolveTenant);
+  const authStateRef = useRef(authState);
 
   useEffect(() => {
     getMeRef.current = authActions.getMe;
     resolveTenantRef.current = authActions.resolveTenant;
   }, [authActions.getMe, authActions.resolveTenant]);
 
+  useEffect(() => {
+    authStateRef.current = authState;
+  }, [authState]);
+
   const refreshSession = useCallback(async () => {
     const token = getCookie(AUTH_COOKIE_NAMES.token);
     const tenancyNameFromLocation = resolveTenancyNameFromLocation();
-    const currentTenant = authState.tenant ?? readTenantFromCookies();
+    const currentTenant = authStateRef.current.tenant ?? readTenantFromCookies();
 
     if (tenancyNameFromLocation && tenancyNameFromLocation !== currentTenant?.tenancyName) {
       await resolveTenantRef.current(tenancyNameFromLocation);
@@ -48,16 +53,16 @@ export const useAppSession = () => {
       setConfigurationError(getApiErrorMessage(error, "We could not load the user configuration."));
     }
 
-    if (token && !authState.isAuthenticated) {
+    if (token && !authStateRef.current.isAuthenticated) {
       await getMeRef.current();
     }
 
-    if (!token && authState.isAuthenticated) {
+    if (!token && authStateRef.current.isAuthenticated) {
       removeCookie(AUTH_COOKIE_NAMES.token);
     }
 
     setIsReady(true);
-  }, [authState.isAuthenticated, authState.tenant]);
+  }, []);
 
   useEffect(() => {
     const bootstrapTimeout = globalThis.setTimeout(() => {

--- a/journeypoint/next.config.ts
+++ b/journeypoint/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
+// Allow self-signed certs when proxying to local backend in development
+if (process.env.NODE_ENV === "development") {
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+}
+
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
 };
 

--- a/journeypoint/utils/axiosInstance.tsx
+++ b/journeypoint/utils/axiosInstance.tsx
@@ -7,7 +7,7 @@ export const getAxiosInstace = () => {
     const tenantId = getCookie(AUTH_COOKIE_NAMES.tenantId);
 
     return axios.create({
-        baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+        baseURL: "/api/proxy",
         headers: {
             "Content-Type": "application/json",
             ...(token ? { Authorization: `Bearer ${token}` } : {}),


### PR DESCRIPTION
Linking Issue: #8 , Linking Pr's: #9 , #10 , #11 

This pull request introduces a new API proxy route in the Next.js app to forward API requests to the backend, centralizes tenant and authorization header handling, and updates the app to use this proxy for API calls. It also makes the session hook more robust and configures development settings for smoother local development. Below are the most important changes:

### API Proxy Implementation

* Added a new catch-all API route at `journeypoint/app/api/proxy/[...path]/route.ts` that proxies requests to the backend, forwarding tenant and authorization headers, and handling errors gracefully. This centralizes backend communication and tenant resolution. ([journeypoint/app/api/proxy/[...path]/route.tsR1-R78](diffhunk://#diff-b7642a08daea7fa38a433b949872239c64e8e06a6c08079a96453bd2b96f59c4R1-R78))

* Updated the Axios instance in `journeypoint/utils/axiosInstance.tsx` to use the new `/api/proxy` endpoint as its base URL, ensuring all frontend API calls are routed through the proxy.

### Session Management Improvements

* Refactored `useAppSession` in `journeypoint/helpers/useAppSession.tsx` to use refs for `authState` and related actions, preventing stale closure issues and ensuring correct session/tenant handling during async operations.

* Simplified the dependencies of the `refreshSession` callback in `useAppSession`, making it independent of `authState` and `tenant` changes, which avoids unnecessary re-renders and potential bugs.

### Developer Experience

* Configured the app in `journeypoint/next.config.ts` to allow self-signed certificates in development mode, making local backend development easier by disabling TLS certificate verification.

### Tooling & Search Enhancements

* Expanded `.claude/settings.json` with additional Bash and PowerShell commands for searching tenant-related contributors and ABP framework sources, improving developer tooling for codebase exploration.