### PR TITLE
Make Spec Kit roadmap canonical; mark T057 done

### DIFF
--- a/.specify/project.md
+++ b/.specify/project.md
@@ -29,6 +29,11 @@ The current delivery initiative is a five-milestone implementation plan:
 4. Journey participation and human-in-the-loop AI
 5. Intelligence, interventions, and demo readiness
 
+This five-milestone plan is the canonical JourneyPoint roadmap for the current
+initiative. Any older GitHub milestone or issue wording that references Angular
+must be treated as historical foundation context only and must not override the
+active feature package or roadmap markdown.
+
 The active feature package must remain detailed enough that Claude, ChatGPT,
 Codex, and GitHub Copilot can continue work from the same documented intent.
 
@@ -67,6 +72,8 @@ specs/     # Active Spec Kit feature packages
 - Prefer reusable domain concepts over one-off demo shortcuts.
 - Preserve audit history for AI runs, engagement scoring, and interventions.
 - Update the roadmap markdown before or alongside any major issue re-slicing.
+- Treat Angular-oriented milestone labels in historical GitHub records as
+  legacy context rather than active roadmap language.
 
 ## Working Commands
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # JourneyPoint
 
-HR management platform for employee data and performance tracking.
+Multi-tenant onboarding platform for reusable onboarding plans, hire journeys,
+AI-assisted enrichment, and engagement tracking.
+
+## Delivery Baseline
+
+Current implementation planning is governed by the active Spec Kit package in
+`specs/001-journeypoint-platform/` and its five-milestone roadmap in
+`specs/001-journeypoint-platform/github-roadmap.md`.
+
+Any pre-existing GitHub milestone or issue language that references Angular is
+historical foundation context only and does not define the current JourneyPoint
+roadmap.
 
 ## Monorepo Structure
 
@@ -8,7 +19,7 @@ HR management platform for employee data and performance tracking.
 JourneyPoint/
   aspnet-core/      # .NET 8 backend (ABP Framework)
   journeypoint/     # Next.js 16 frontend
-  angular/          # Angular frontend (reference locally, not deployed)
+  angular/          # Legacy Angular frontend kept only as local reference
 ```
 
 ## Quick Start
@@ -32,6 +43,10 @@ npm run dev       # http://localhost:3000
 
 ## Architecture
 
-The backend exposes a REST API secured with JWT. The Next.js frontend consumes it via Axios, configured through `NEXT_PUBLIC_API_BASE_URL`.
+The backend exposes a REST API secured with JWT. The Next.js frontend consumes
+it via Axios, configured through `NEXT_PUBLIC_API_BASE_URL`.
+
+Planning and implementation intent live in the active JourneyPoint Spec Kit
+artifacts rather than legacy GitHub milestone names.
 
 See each directory's own `README.md` for detailed setup and structure.

--- a/specs/001-journeypoint-platform/github-roadmap.md
+++ b/specs/001-journeypoint-platform/github-roadmap.md
@@ -1,5 +1,9 @@
 # JourneyPoint GitHub Roadmap
 
+This document is the canonical JourneyPoint roadmap for current delivery.
+Historical GitHub milestone or issue language that references Angular records
+earlier foundation work only and does not define current scope.
+
 ## Snapshot of Existing GitHub State
 
 Snapshot date: 2026-03-26
@@ -35,13 +39,14 @@ Snapshot date: 2026-03-26
 | #11 | fix: reorder ABP initialization in Configure method for consistency | 2026-03-26T08:53:49Z | feat/frontend-auth-multi-tenancy |
 | #12 | Implement multi-tenant proxy API and update Axios base URL | 2026-03-26T09:26:37Z | feat/frontend-auth-multi-tenancy |
 
-### Roadmap recommendation
+### Canonical baseline
 
 - Keep the existing issues and PRs as historical foundation work.
-- Close or rename milestone `#1` so its title no longer references Angular.
-- Create the new five-milestone roadmap below as the canonical JourneyPoint plan.
+- Treat milestone `#1` and its Angular-oriented wording as legacy context only.
+- Use the five milestones and issue slices below as the canonical JourneyPoint
+  roadmap baseline.
 
-## Proposed Five Milestones
+## Canonical Five Milestones
 
 | Milestone | Goal | Issue Count |
 |----------|------|-------------|
@@ -51,9 +56,9 @@ Snapshot date: 2026-03-26
 | M4 - Participant Experience and Human-in-the-Loop AI | Deliver enrolee, manager, and personalisation flows | 6 |
 | M5 - Intelligence, Interventions, and Demo Readiness | Deliver scoring, pipeline, interventions, and seed validation | 6 |
 
-Total proposed issues: 30
+Total canonical issues: 30
 
-## Proposed Issues
+## Canonical Issues
 
 ### M1 - Platform Foundation and Access
 
@@ -190,9 +195,11 @@ Total proposed issues: 30
    - Scope: Boxfusion and DeptDemo seed state plus milestone smoke validation
    - Depends on: JP-028, JP-029
 
-## Suggested GitHub Creation Order
+## GitHub Alignment Guidance
 
-1. Create all five milestones.
-2. Create M1 issues first and close or rename the old milestone.
-3. Create M2 through M5 issues in dependency order.
-4. Link each PR back to one roadmap issue and one milestone.
+1. Ensure GitHub milestone names align with the five canonical milestones above.
+2. Rename or close milestone `#1` so Angular-oriented wording remains
+   historical only.
+3. Treat legacy issues `#1`, `#2`, and `#8`, plus merged PRs `#3` through
+   `#12`, as historical foundation evidence rather than roadmap-defining slices.
+4. Link ongoing PRs back to one canonical JP issue and one canonical milestone.

--- a/specs/001-journeypoint-platform/tasks.md
+++ b/specs/001-journeypoint-platform/tasks.md
@@ -154,7 +154,7 @@ engagement data, surfaces at-risk hires, and supports facilitator intervention.
 - [ ] T054 [P] Update onboarding architecture and delivery notes in `README.md`, `.specify/project.md`, and `specs/001-journeypoint-platform/quickstart.md`
 - [ ] T055 [P] Update cross-agent guidance in `AGENTS.md`, `CLAUDE.md`, `journeypoint/AGENTS.md`, `journeypoint/CLAUDE.md`, and `.github/copilot-instructions.md`
 - [ ] T056 Run milestone smoke validation using `specs/001-journeypoint-platform/quickstart.md`
-- [ ] T057 Review issue slicing and milestone readiness in `specs/001-journeypoint-platform/github-roadmap.md`
+- [x] T057 Review issue slicing and milestone readiness in `specs/001-journeypoint-platform/github-roadmap.md`
 
 ---
 


### PR DESCRIPTION
Linking Issue: #13 

Clarify that the Spec Kit five-milestone roadmap is the canonical JourneyPoint delivery plan and that older GitHub milestone/issue wording referencing Angular is historical context only. Updates: .specify/project.md adds canonical roadmap language and legacy-Angular guidance; README.md updates product description, adds a Delivery Baseline section referencing the active Spec Kit, and marks the Angular frontend as legacy/local reference; specs/001-journeypoint-platform/github-roadmap.md reworks headings and guidance to treat milestone #1 and Angular-oriented wording as legacy while defining the canonical five milestones and alignment steps; specs/001-journeypoint-platform/tasks.md marks T057 as completed. These changes align repository docs and GitHub milestone guidance with the active Spec Kit intent.