### PR TITLE
Clarify source-of-truth and update agent docs

### DIFF
--- a/.codex/context.md
+++ b/.codex/context.md
@@ -16,6 +16,16 @@ engagement scoring, and at-risk follow-up.
 
 ## Operating rule
 
-Before implementing any feature, use `specs/001-journeypoint-platform/` as the
-source of truth together with `.specify/memory/constitution.md` and
-`.specify/project.md`.
+`AGENTS.md` is the root operating guide for Codex work in this repository.
+
+Use this source-of-truth order before implementing any feature:
+
+1. `.specify/memory/constitution.md`
+2. `.specify/project.md`
+3. the active feature package `specs/001-journeypoint-platform/`:
+   `spec.md`, `plan.md`, `tasks.md`, and `github-roadmap.md`
+4. `.codex/context.md`, then `.codex/backend.md` or `.codex/frontend.md` as
+   relevant
+
+Do not infer the active feature package from branch names. Ignore the
+`angular/` application for current planning and implementation.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,15 +2,18 @@
 
 This repository uses spec-driven delivery.
 
-Read first:
+`AGENTS.md` is the root operating guide for repository guidance.
 
-1. `AGENTS.md`
-2. `.specify/memory/constitution.md`
-3. `.specify/project.md`
-4. `specs/001-journeypoint-platform/spec.md`
-5. `specs/001-journeypoint-platform/plan.md`
-6. `specs/001-journeypoint-platform/tasks.md`
-7. `specs/001-journeypoint-platform/github-roadmap.md`
+## Canonical Source of Truth
+
+After reading `AGENTS.md`, follow this order:
+
+1. `.specify/memory/constitution.md`
+2. `.specify/project.md`
+3. the active feature package `specs/001-journeypoint-platform/`:
+   `spec.md`, `plan.md`, `tasks.md`, and `github-roadmap.md`
+4. lower-priority assistant guidance files such as this file, `CLAUDE.md`, and
+   `.codex/context.md`
 
 Stack:
 
@@ -21,6 +24,8 @@ Stack:
 
 Rules:
 
+- keep `specs/001-journeypoint-platform/` as the active feature package unless
+  the project docs explicitly change it
 - ignore `angular/`
 - preserve ABP layering
 - preserve tenant and auth behavior

--- a/.specify/project.md
+++ b/.specify/project.md
@@ -19,6 +19,11 @@ surfacing at-risk interventions early.
 If two documents disagree, prefer the higher item in this list and update the
 lower one before continuing.
 
+The active feature package remains `specs/001-journeypoint-platform/` for the
+current initiative even when contributors work from task-specific or
+documentation branches. Do not infer a different feature package from branch
+names or legacy GitHub milestone wording.
+
 ## Active Delivery Scope
 
 The current delivery initiative is a five-milestone implementation plan:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,26 @@
 # JourneyPoint Agent Guide
 
-## Read Order
+This is the root operating guide for repository contributors and assistant
+tools.
 
-Before making or proposing changes, read these in order:
+## Canonical Source of Truth
+
+Before making or proposing changes, follow this order:
 
 1. `.specify/memory/constitution.md`
 2. `.specify/project.md`
-3. `specs/001-journeypoint-platform/spec.md`
-4. `specs/001-journeypoint-platform/plan.md`
-5. `specs/001-journeypoint-platform/tasks.md`
-6. `specs/001-journeypoint-platform/github-roadmap.md`
-7. `.codex/context.md` plus `.codex/backend.md` or `.codex/frontend.md` as relevant
+3. the active feature package `specs/001-journeypoint-platform/`:
+   `spec.md`, `plan.md`, `tasks.md`, and `github-roadmap.md`
+4. lower-priority assistant guidance files such as `CLAUDE.md`,
+   `.github/copilot-instructions.md`, and `.codex/context.md`
+5. `.codex/backend.md` or `.codex/frontend.md` as relevant
+
+If two documents disagree, prefer the higher item and update the lower item
+before continuing.
+
+The active feature package is currently `001-journeypoint-platform`. Do not
+infer a different package from the current branch name or from historical
+GitHub milestone wording.
 
 ## Project Identity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,22 @@
 # Claude Code Instructions for JourneyPoint
 
-Read these first:
+`AGENTS.md` is the root operating guide for this repository.
 
-1. `AGENTS.md`
-2. `.specify/memory/constitution.md`
-3. `.specify/project.md`
-4. `specs/001-journeypoint-platform/spec.md`
-5. `specs/001-journeypoint-platform/plan.md`
-6. `specs/001-journeypoint-platform/tasks.md`
-7. `specs/001-journeypoint-platform/github-roadmap.md`
+## Canonical Source of Truth
+
+After reading `AGENTS.md`, follow this order:
+
+1. `.specify/memory/constitution.md`
+2. `.specify/project.md`
+3. the active feature package `specs/001-journeypoint-platform/`:
+   `spec.md`, `plan.md`, `tasks.md`, and `github-roadmap.md`
+4. lower-priority assistant guidance files such as this file,
+   `.github/copilot-instructions.md`, and `.codex/context.md`
 
 JourneyPoint uses spec-driven delivery.
+
+Do not infer the active feature package from branch names or historical GitHub
+milestone wording. `angular/` is out of scope.
 
 When implementing:
 

--- a/journeypoint/AGENTS.md
+++ b/journeypoint/AGENTS.md
@@ -1,6 +1,7 @@
 # JourneyPoint Frontend Agent Guide
 
 This file supplements the root `AGENTS.md` for work inside `journeypoint/`.
+It does not override the canonical source-of-truth order defined there.
 
 ## Mandatory source of truth
 
@@ -9,11 +10,13 @@ Before making frontend changes, read:
 1. `../AGENTS.md`
 2. `../.specify/memory/constitution.md`
 3. `../.specify/project.md`
-4. `../specs/001-journeypoint-platform/spec.md`
-5. `../specs/001-journeypoint-platform/plan.md`
-6. `../specs/001-journeypoint-platform/tasks.md`
-7. `../specs/001-journeypoint-platform/github-roadmap.md`
-8. `../.codex/frontend.md`
+4. the active feature package `../specs/001-journeypoint-platform/`:
+   `spec.md`, `plan.md`, `tasks.md`, and `github-roadmap.md`
+5. `../.codex/context.md`
+6. `../.codex/frontend.md`
+
+Do not infer a different feature package from the current branch name. Ignore
+`../angular/`.
 
 ## Frontend rules
 

--- a/journeypoint/CLAUDE.md
+++ b/journeypoint/CLAUDE.md
@@ -1,14 +1,20 @@
 # Claude Code Instructions for JourneyPoint Frontend
 
-Read these first:
+`../AGENTS.md` is the root operating guide for frontend work.
 
-1. `../AGENTS.md`
-2. `../.specify/memory/constitution.md`
-3. `../.specify/project.md`
-4. `../specs/001-journeypoint-platform/spec.md`
-5. `../specs/001-journeypoint-platform/plan.md`
-6. `../specs/001-journeypoint-platform/tasks.md`
-7. `../specs/001-journeypoint-platform/github-roadmap.md`
+## Canonical Source of Truth
+
+After reading `../AGENTS.md`, follow this order:
+
+1. `../.specify/memory/constitution.md`
+2. `../.specify/project.md`
+3. the active feature package `../specs/001-journeypoint-platform/`:
+   `spec.md`, `plan.md`, `tasks.md`, and `github-roadmap.md`
+4. `../.codex/context.md`
+5. `../.codex/frontend.md`
+
+Do not infer the active feature package from branch names. `../angular/` is out
+of scope.
 
 When implementing:
 

--- a/specs/001-journeypoint-platform/tasks.md
+++ b/specs/001-journeypoint-platform/tasks.md
@@ -152,7 +152,7 @@ engagement data, surfaces at-risk hires, and supports facilitator intervention.
 **Purpose**: Finalize documentation, smoke validation, and readiness artifacts.
 
 - [ ] T054 [P] Update onboarding architecture and delivery notes in `README.md`, `.specify/project.md`, and `specs/001-journeypoint-platform/quickstart.md`
-- [ ] T055 [P] Update cross-agent guidance in `AGENTS.md`, `CLAUDE.md`, `journeypoint/AGENTS.md`, `journeypoint/CLAUDE.md`, and `.github/copilot-instructions.md`
+- [x] T055 [P] Update cross-agent guidance in `AGENTS.md`, `CLAUDE.md`, `journeypoint/AGENTS.md`, `journeypoint/CLAUDE.md`, and `.github/copilot-instructions.md`
 - [ ] T056 Run milestone smoke validation using `specs/001-journeypoint-platform/quickstart.md`
 - [x] T057 Review issue slicing and milestone readiness in `specs/001-journeypoint-platform/github-roadmap.md`
 


### PR DESCRIPTION
Linking Issues: #14 

Make AGENTS.md the root operating guide and standardize the canonical source-of-truth ordering across repository guidance files. Updated .codex/context.md, .github/copilot-instructions.md, .specify/project.md, AGENTS.md, CLAUDE.md, journeypoint/AGENTS.md, and journeypoint/CLAUDE.md to reference the active feature package (specs/001-journeypoint-platform/) and instruct contributors not to infer active packages from branch names or legacy milestone wording. Also adjusted frontend-specific guidance and marked T055 complete in specs/001-journeypoint-platform/tasks.md.