### PR TITLE
Update onboarding standards and backend planning foundations

### DIFF
--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/CloneOnboardingPlanRequest.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/CloneOnboardingPlanRequest.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Defines the input used to clone an onboarding plan into a new draft.
+    /// </summary>
+    public class CloneOnboardingPlanRequest
+    {
+        /// <summary>
+        /// Gets or sets the source onboarding plan identifier.
+        /// </summary>
+        public Guid SourcePlanId { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional override for the cloned plan name.
+        /// </summary>
+        [MaxLength(OnboardingPlan.MaxNameLength)]
+        public string Name { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/CreateOnboardingPlanRequest.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/CreateOnboardingPlanRequest.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Defines the input required to create a draft onboarding plan.
+    /// </summary>
+    public class CreateOnboardingPlanRequest
+    {
+        public CreateOnboardingPlanRequest()
+        {
+            Modules = new List<UpsertOnboardingModuleDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan name.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxNameLength)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target audience.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxTargetAudienceLength)]
+        public string TargetAudience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration in days.
+        /// </summary>
+        [Range(OnboardingPlan.MinDurationDays, int.MaxValue)]
+        public int DurationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered module collection to create with the plan.
+        /// </summary>
+        public List<UpsertOnboardingModuleDto> Modules { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/GetOnboardingPlansInput.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/GetOnboardingPlansInput.cs
@@ -1,0 +1,21 @@
+using Abp.Application.Services.Dto;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Defines filtering and paging for onboarding plan list queries.
+    /// </summary>
+    public class GetOnboardingPlansInput : PagedAndSortedResultRequestDto
+    {
+        /// <summary>
+        /// Gets or sets an optional keyword matched against plan name or target audience.
+        /// </summary>
+        public string Keyword { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional lifecycle filter.
+        /// </summary>
+        public OnboardingPlanStatus? Status { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingModuleDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingModuleDto.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Represents one ordered onboarding module in the plan builder contract.
+    /// </summary>
+    public class OnboardingModuleDto
+    {
+        public OnboardingModuleDto()
+        {
+            Tasks = new List<OnboardingTaskDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the module identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the plan-local module order index.
+        /// </summary>
+        public int OrderIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered task collection inside the module.
+        /// </summary>
+        public List<OnboardingTaskDto> Tasks { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingPlanDetailDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingPlanDetailDto.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Represents the full onboarding plan payload for the plan builder UI.
+    /// </summary>
+    public class OnboardingPlanDetailDto
+    {
+        public OnboardingPlanDetailDto()
+        {
+            Modules = new List<OnboardingModuleDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the intended onboarding audience.
+        /// </summary>
+        public string TargetAudience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration in days.
+        /// </summary>
+        public int DurationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current lifecycle state.
+        /// </summary>
+        public OnboardingPlanStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered module collection.
+        /// </summary>
+        public List<OnboardingModuleDto> Modules { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingPlanListItemDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingPlanListItemDto.cs
@@ -1,0 +1,51 @@
+using System;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Represents a lightweight onboarding plan record for list views.
+    /// </summary>
+    public class OnboardingPlanListItemDto
+    {
+        /// <summary>
+        /// Gets or sets the onboarding plan identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the intended onboarding audience.
+        /// </summary>
+        public string TargetAudience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the onboarding duration in days.
+        /// </summary>
+        public int DurationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current lifecycle state.
+        /// </summary>
+        public OnboardingPlanStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of modules in the plan.
+        /// </summary>
+        public int ModuleCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of template tasks in the plan.
+        /// </summary>
+        public int TaskCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the most recent edit timestamp or creation time if never edited.
+        /// </summary>
+        public DateTime LastUpdatedTime { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingTaskDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/OnboardingTaskDto.cs
@@ -1,0 +1,51 @@
+using System;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Represents one ordered template task in the onboarding plan builder contract.
+    /// </summary>
+    public class OnboardingTaskDto
+    {
+        /// <summary>
+        /// Gets or sets the template task identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task title.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task category.
+        /// </summary>
+        public OnboardingTaskCategory Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module-local order index.
+        /// </summary>
+        public int OrderIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the due day offset from the hire start date.
+        /// </summary>
+        public int DueDayOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target actor responsible for the task.
+        /// </summary>
+        public OnboardingTaskAssignmentTarget AssignmentTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets the acknowledgement rule for the task.
+        /// </summary>
+        public OnboardingTaskAcknowledgementRule AcknowledgementRule { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/UpdateOnboardingPlanRequest.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/UpdateOnboardingPlanRequest.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Defines the full replacement payload for a draft onboarding plan editor save.
+    /// </summary>
+    public class UpdateOnboardingPlanRequest
+    {
+        public UpdateOnboardingPlanRequest()
+        {
+            Modules = new List<UpsertOnboardingModuleDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan name.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxNameLength)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the onboarding plan description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target audience.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxTargetAudienceLength)]
+        public string TargetAudience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration in days.
+        /// </summary>
+        [Range(OnboardingPlan.MinDurationDays, int.MaxValue)]
+        public int DurationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered module collection for the full draft save.
+        /// </summary>
+        public List<UpsertOnboardingModuleDto> Modules { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/UpsertOnboardingModuleDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/UpsertOnboardingModuleDto.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Defines module input used during onboarding plan create and update operations.
+    /// </summary>
+    public class UpsertOnboardingModuleDto
+    {
+        public UpsertOnboardingModuleDto()
+        {
+            Tasks = new List<UpsertOnboardingTaskDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the optional module identifier for existing draft modules.
+        /// </summary>
+        public Guid? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module name.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingModule.MaxNameLength)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingModule.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the plan-local order index.
+        /// </summary>
+        [Range(OnboardingModule.MinOrderIndex, int.MaxValue)]
+        public int OrderIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered task collection for the module.
+        /// </summary>
+        public List<UpsertOnboardingTaskDto> Tasks { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/UpsertOnboardingTaskDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/Dto/UpsertOnboardingTaskDto.cs
@@ -1,0 +1,58 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService.Dto
+{
+    /// <summary>
+    /// Defines task input used during onboarding plan create and update operations.
+    /// </summary>
+    public class UpsertOnboardingTaskDto
+    {
+        /// <summary>
+        /// Gets or sets the optional task identifier for existing draft tasks.
+        /// </summary>
+        public Guid? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task title.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingTask.MaxTitleLength)]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingTask.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task category.
+        /// </summary>
+        public OnboardingTaskCategory Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module-local order index.
+        /// </summary>
+        [Range(OnboardingTask.MinOrderIndex, int.MaxValue)]
+        public int OrderIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the due day offset.
+        /// </summary>
+        [Range(OnboardingTask.MinDueDayOffset, int.MaxValue)]
+        public int DueDayOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the assignment target.
+        /// </summary>
+        public OnboardingTaskAssignmentTarget AssignmentTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets the acknowledgement rule.
+        /// </summary>
+        public OnboardingTaskAcknowledgementRule AcknowledgementRule { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/IOnboardingPlanAppService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/IOnboardingPlanAppService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using Abp.Application.Services;
+using Abp.Application.Services.Dto;
+using JourneyPoint.Application.Services.OnboardingPlanService.Dto;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService
+{
+    /// <summary>
+    /// Defines application-service operations for reusable onboarding plan management.
+    /// </summary>
+    public interface IOnboardingPlanAppService : IApplicationService
+    {
+        /// <summary>
+        /// Returns a filtered page of tenant-scoped onboarding plans.
+        /// </summary>
+        Task<PagedResultDto<OnboardingPlanListItemDto>> GetPlansAsync(GetOnboardingPlansInput input);
+
+        /// <summary>
+        /// Returns one onboarding plan with ordered modules and tasks for the plan builder.
+        /// </summary>
+        Task<OnboardingPlanDetailDto> GetDetailAsync(EntityDto<Guid> input);
+
+        /// <summary>
+        /// Creates a new draft onboarding plan.
+        /// </summary>
+        Task<OnboardingPlanDetailDto> CreateAsync(CreateOnboardingPlanRequest input);
+
+        /// <summary>
+        /// Updates a draft onboarding plan and its ordered module/task structure.
+        /// </summary>
+        Task<OnboardingPlanDetailDto> UpdateAsync(UpdateOnboardingPlanRequest input);
+
+        /// <summary>
+        /// Publishes a draft onboarding plan.
+        /// </summary>
+        Task<OnboardingPlanDetailDto> PublishAsync(EntityDto<Guid> input);
+
+        /// <summary>
+        /// Archives an onboarding plan.
+        /// </summary>
+        Task<OnboardingPlanDetailDto> ArchiveAsync(EntityDto<Guid> input);
+
+        /// <summary>
+        /// Creates a draft copy of an existing onboarding plan.
+        /// </summary>
+        Task<OnboardingPlanDetailDto> CloneAsync(CloneOnboardingPlanRequest input);
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/OnboardingPlanAppService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/OnboardingPlanAppService.cs
@@ -1,0 +1,395 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Application.Services.Dto;
+using Abp.Authorization;
+using Abp.Domain.Entities;
+using Abp.Domain.Repositories;
+using Abp.Linq.Extensions;
+using JourneyPoint.Application.Services.OnboardingPlanService.Dto;
+using JourneyPoint.Authorization;
+using JourneyPoint.Domains.OnboardingPlans;
+using Microsoft.EntityFrameworkCore;
+
+namespace JourneyPoint.Application.Services.OnboardingPlanService
+{
+    /// <summary>
+    /// Provides tenant-scoped onboarding plan CRUD and lifecycle orchestration.
+    /// </summary>
+    [AbpAuthorize(PermissionNames.Pages_JourneyPoint_Facilitator, PermissionNames.Pages_JourneyPoint_TenantAdmin)]
+    public class OnboardingPlanAppService : JourneyPointAppServiceBase, IOnboardingPlanAppService
+    {
+        private const string CloneSuffix = " Copy";
+
+        private readonly IRepository<OnboardingPlan, Guid> _onboardingPlanRepository;
+        private readonly IRepository<OnboardingModule, Guid> _onboardingModuleRepository;
+        private readonly IRepository<OnboardingTask, Guid> _onboardingTaskRepository;
+        private readonly OnboardingPlanManager _onboardingPlanManager;
+
+        public OnboardingPlanAppService(
+            IRepository<OnboardingPlan, Guid> onboardingPlanRepository,
+            IRepository<OnboardingModule, Guid> onboardingModuleRepository,
+            IRepository<OnboardingTask, Guid> onboardingTaskRepository,
+            OnboardingPlanManager onboardingPlanManager)
+        {
+            _onboardingPlanRepository = onboardingPlanRepository;
+            _onboardingModuleRepository = onboardingModuleRepository;
+            _onboardingTaskRepository = onboardingTaskRepository;
+            _onboardingPlanManager = onboardingPlanManager;
+        }
+
+        /// <summary>
+        /// Returns a filtered page of tenant-scoped onboarding plans.
+        /// </summary>
+        public async Task<PagedResultDto<OnboardingPlanListItemDto>> GetPlansAsync(GetOnboardingPlansInput input)
+        {
+            var tenantId = GetRequiredTenantId();
+            var normalizedInput = input ?? new GetOnboardingPlansInput();
+            var query = _onboardingPlanRepository.GetAll()
+                .AsNoTracking()
+                .Where(plan => plan.TenantId == tenantId)
+                .WhereIf(!string.IsNullOrWhiteSpace(normalizedInput.Keyword),
+                    plan => plan.Name.Contains(normalizedInput.Keyword) || plan.TargetAudience.Contains(normalizedInput.Keyword))
+                .WhereIf(normalizedInput.Status.HasValue, plan => plan.Status == normalizedInput.Status.Value);
+
+            var totalCount = await query.CountAsync();
+            var items = await query
+                .OrderByDescending(plan => plan.LastModificationTime ?? plan.CreationTime)
+                .PageBy(normalizedInput)
+                .Select(plan => new OnboardingPlanListItemDto
+                {
+                    Id = plan.Id,
+                    Name = plan.Name,
+                    TargetAudience = plan.TargetAudience,
+                    DurationDays = plan.DurationDays,
+                    Status = plan.Status,
+                    ModuleCount = plan.Modules.Count,
+                    TaskCount = plan.Modules.SelectMany(module => module.Tasks).Count(),
+                    LastUpdatedTime = plan.LastModificationTime ?? plan.CreationTime
+                })
+                .ToListAsync();
+
+            return new PagedResultDto<OnboardingPlanListItemDto>(totalCount, items);
+        }
+
+        /// <summary>
+        /// Returns one onboarding plan with ordered modules and tasks.
+        /// </summary>
+        public async Task<OnboardingPlanDetailDto> GetDetailAsync(EntityDto<Guid> input)
+        {
+            var plan = await GetPlanForReadAsync(input.Id);
+            return MapToDetailDto(plan);
+        }
+
+        /// <summary>
+        /// Creates a new draft onboarding plan.
+        /// </summary>
+        public async Task<OnboardingPlanDetailDto> CreateAsync(CreateOnboardingPlanRequest input)
+        {
+            var tenantId = GetRequiredTenantId();
+            var plan = _onboardingPlanManager.CreatePlan(tenantId, input.Name, input.Description, input.TargetAudience, input.DurationDays);
+
+            ApplyModuleInputs(plan, input.Modules);
+
+            await _onboardingPlanRepository.InsertAsync(plan);
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            var persistedPlan = await GetPlanForReadAsync(plan.Id);
+            return MapToDetailDto(persistedPlan);
+        }
+
+        /// <summary>
+        /// Updates a draft onboarding plan and its full ordered structure.
+        /// </summary>
+        public async Task<OnboardingPlanDetailDto> UpdateAsync(UpdateOnboardingPlanRequest input)
+        {
+            var plan = await GetPlanForEditAsync(input.Id);
+
+            _onboardingPlanManager.UpdatePlanDetails(plan, input.Name, input.Description, input.TargetAudience, input.DurationDays);
+            await SyncModulesAsync(plan, input.Modules);
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            var persistedPlan = await GetPlanForReadAsync(plan.Id);
+            return MapToDetailDto(persistedPlan);
+        }
+
+        /// <summary>
+        /// Publishes a draft onboarding plan.
+        /// </summary>
+        public async Task<OnboardingPlanDetailDto> PublishAsync(EntityDto<Guid> input)
+        {
+            var plan = await GetPlanForEditAsync(input.Id);
+
+            _onboardingPlanManager.Publish(plan);
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            return MapToDetailDto(plan);
+        }
+
+        /// <summary>
+        /// Archives an onboarding plan.
+        /// </summary>
+        public async Task<OnboardingPlanDetailDto> ArchiveAsync(EntityDto<Guid> input)
+        {
+            var plan = await GetPlanForEditAsync(input.Id);
+
+            _onboardingPlanManager.Archive(plan);
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            return MapToDetailDto(plan);
+        }
+
+        /// <summary>
+        /// Creates a draft copy of an existing onboarding plan with preserved ordering.
+        /// </summary>
+        public async Task<OnboardingPlanDetailDto> CloneAsync(CloneOnboardingPlanRequest input)
+        {
+            var tenantId = GetRequiredTenantId();
+            var sourcePlan = await GetPlanForReadAsync(input.SourcePlanId);
+            var cloneName = string.IsNullOrWhiteSpace(input.Name) ? $"{sourcePlan.Name}{CloneSuffix}" : input.Name;
+            var clonePlan = _onboardingPlanManager.CreatePlan(tenantId, cloneName, sourcePlan.Description, sourcePlan.TargetAudience, sourcePlan.DurationDays);
+
+            foreach (var sourceModule in sourcePlan.Modules.OrderBy(module => module.OrderIndex))
+            {
+                var cloneModule = _onboardingPlanManager.CreateModule(sourceModule.Name, sourceModule.Description, sourceModule.OrderIndex);
+                _onboardingPlanManager.AddModule(clonePlan, cloneModule);
+
+                foreach (var sourceTask in sourceModule.Tasks.OrderBy(task => task.OrderIndex))
+                {
+                    var cloneTask = _onboardingPlanManager.CreateTask(
+                        sourceTask.Title,
+                        sourceTask.Description,
+                        sourceTask.Category,
+                        sourceTask.OrderIndex,
+                        sourceTask.DueDayOffset,
+                        sourceTask.AssignmentTarget,
+                        sourceTask.AcknowledgementRule);
+
+                    _onboardingPlanManager.AddTask(clonePlan, cloneModule.Id, cloneTask);
+                }
+            }
+
+            await _onboardingPlanRepository.InsertAsync(clonePlan);
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            var persistedPlan = await GetPlanForReadAsync(clonePlan.Id);
+            return MapToDetailDto(persistedPlan);
+        }
+
+        private void ApplyModuleInputs(OnboardingPlan plan, IEnumerable<UpsertOnboardingModuleDto> moduleInputs)
+        {
+            foreach (var moduleInput in OrderModules(moduleInputs))
+            {
+                var module = _onboardingPlanManager.CreateModule(moduleInput.Name, moduleInput.Description, moduleInput.OrderIndex);
+                _onboardingPlanManager.AddModule(plan, module);
+
+                foreach (var taskInput in OrderTasks(moduleInput.Tasks))
+                {
+                    var task = _onboardingPlanManager.CreateTask(
+                        taskInput.Title,
+                        taskInput.Description,
+                        taskInput.Category,
+                        taskInput.OrderIndex,
+                        taskInput.DueDayOffset,
+                        taskInput.AssignmentTarget,
+                        taskInput.AcknowledgementRule);
+
+                    _onboardingPlanManager.AddTask(plan, module.Id, task);
+                }
+            }
+        }
+
+        private async Task SyncModulesAsync(OnboardingPlan plan, IEnumerable<UpsertOnboardingModuleDto> moduleInputs)
+        {
+            var existingModuleIds = plan.Modules.Select(module => module.Id).ToHashSet();
+            var orderedModuleInputs = OrderModules(moduleInputs).ToList();
+            var requestedModuleIds = orderedModuleInputs
+                .Where(module => module.Id.HasValue)
+                .Select(module => module.Id.Value)
+                .ToHashSet();
+
+            foreach (var moduleInput in orderedModuleInputs)
+            {
+                if (moduleInput.Id.HasValue)
+                {
+                    _onboardingPlanManager.UpdateModule(plan, moduleInput.Id.Value, moduleInput.Name, moduleInput.Description, moduleInput.OrderIndex);
+                    var existingModule = plan.Modules.Single(module => module.Id == moduleInput.Id.Value);
+                    await SyncTasksAsync(plan, existingModule, moduleInput.Tasks);
+                    continue;
+                }
+
+                var newModule = _onboardingPlanManager.CreateModule(moduleInput.Name, moduleInput.Description, moduleInput.OrderIndex);
+                _onboardingPlanManager.AddModule(plan, newModule);
+                await SyncTasksAsync(plan, newModule, moduleInput.Tasks);
+            }
+
+            var modulesToDelete = plan.Modules
+                .Where(module => existingModuleIds.Contains(module.Id) && !requestedModuleIds.Contains(module.Id))
+                .ToList();
+
+            foreach (var module in modulesToDelete)
+            {
+                plan.Modules.Remove(module);
+                await _onboardingModuleRepository.DeleteAsync(module);
+            }
+        }
+
+        private async Task SyncTasksAsync(OnboardingPlan plan, OnboardingModule module, IEnumerable<UpsertOnboardingTaskDto> taskInputs)
+        {
+            var existingTaskIds = module.Tasks.Select(task => task.Id).ToHashSet();
+            var orderedTaskInputs = OrderTasks(taskInputs).ToList();
+            var requestedTaskIds = orderedTaskInputs
+                .Where(task => task.Id.HasValue)
+                .Select(task => task.Id.Value)
+                .ToHashSet();
+
+            foreach (var taskInput in orderedTaskInputs)
+            {
+                if (taskInput.Id.HasValue)
+                {
+                    _onboardingPlanManager.UpdateTask(
+                        plan,
+                        module.Id,
+                        taskInput.Id.Value,
+                        taskInput.Title,
+                        taskInput.Description,
+                        taskInput.Category,
+                        taskInput.OrderIndex,
+                        taskInput.DueDayOffset,
+                        taskInput.AssignmentTarget,
+                        taskInput.AcknowledgementRule);
+
+                    continue;
+                }
+
+                var newTask = _onboardingPlanManager.CreateTask(
+                    taskInput.Title,
+                    taskInput.Description,
+                    taskInput.Category,
+                    taskInput.OrderIndex,
+                    taskInput.DueDayOffset,
+                    taskInput.AssignmentTarget,
+                    taskInput.AcknowledgementRule);
+
+                _onboardingPlanManager.AddTask(plan, module.Id, newTask);
+            }
+
+            var tasksToDelete = module.Tasks
+                .Where(task => existingTaskIds.Contains(task.Id) && !requestedTaskIds.Contains(task.Id))
+                .ToList();
+
+            foreach (var task in tasksToDelete)
+            {
+                module.Tasks.Remove(task);
+                await _onboardingTaskRepository.DeleteAsync(task);
+            }
+        }
+
+        private async Task<OnboardingPlan> GetPlanForReadAsync(Guid planId)
+        {
+            var tenantId = GetRequiredTenantId();
+            var plan = await _onboardingPlanRepository.GetAll()
+                .AsNoTracking()
+                .Where(planEntity => planEntity.TenantId == tenantId && planEntity.Id == planId)
+                .Include(planEntity => planEntity.Modules)
+                .ThenInclude(module => module.Tasks)
+                .SingleOrDefaultAsync();
+
+            if (plan == null)
+            {
+                throw new EntityNotFoundException(typeof(OnboardingPlan), planId);
+            }
+
+            return plan;
+        }
+
+        private async Task<OnboardingPlan> GetPlanForEditAsync(Guid planId)
+        {
+            var tenantId = GetRequiredTenantId();
+            var plan = await _onboardingPlanRepository.GetAll()
+                .Where(planEntity => planEntity.TenantId == tenantId && planEntity.Id == planId)
+                .Include(planEntity => planEntity.Modules)
+                .ThenInclude(module => module.Tasks)
+                .SingleOrDefaultAsync();
+
+            if (plan == null)
+            {
+                throw new EntityNotFoundException(typeof(OnboardingPlan), planId);
+            }
+
+            return plan;
+        }
+
+        private int GetRequiredTenantId()
+        {
+            if (!AbpSession.TenantId.HasValue)
+            {
+                throw new AbpAuthorizationException("Onboarding plan management requires a tenant context.");
+            }
+
+            return AbpSession.TenantId.Value;
+        }
+
+        private static IEnumerable<UpsertOnboardingModuleDto> OrderModules(IEnumerable<UpsertOnboardingModuleDto> modules)
+        {
+            return (modules ?? Enumerable.Empty<UpsertOnboardingModuleDto>())
+                .OrderBy(module => module.OrderIndex)
+                .ThenBy(module => module.Id ?? Guid.Empty);
+        }
+
+        private static IEnumerable<UpsertOnboardingTaskDto> OrderTasks(IEnumerable<UpsertOnboardingTaskDto> tasks)
+        {
+            return (tasks ?? Enumerable.Empty<UpsertOnboardingTaskDto>())
+                .OrderBy(task => task.OrderIndex)
+                .ThenBy(task => task.Id ?? Guid.Empty);
+        }
+
+        private static OnboardingPlanDetailDto MapToDetailDto(OnboardingPlan plan)
+        {
+            return new OnboardingPlanDetailDto
+            {
+                Id = plan.Id,
+                Name = plan.Name,
+                Description = plan.Description,
+                TargetAudience = plan.TargetAudience,
+                DurationDays = plan.DurationDays,
+                Status = plan.Status,
+                Modules = plan.Modules
+                    .OrderBy(module => module.OrderIndex)
+                    .Select(MapModuleDto)
+                    .ToList()
+            };
+        }
+
+        private static OnboardingModuleDto MapModuleDto(OnboardingModule module)
+        {
+            return new OnboardingModuleDto
+            {
+                Id = module.Id,
+                Name = module.Name,
+                Description = module.Description,
+                OrderIndex = module.OrderIndex,
+                Tasks = module.Tasks
+                    .OrderBy(task => task.OrderIndex)
+                    .Select(MapTaskDto)
+                    .ToList()
+            };
+        }
+
+        private static OnboardingTaskDto MapTaskDto(OnboardingTask task)
+        {
+            return new OnboardingTaskDto
+            {
+                Id = task.Id,
+                Title = task.Title,
+                Description = task.Description,
+                Category = task.Category,
+                OrderIndex = task.OrderIndex,
+                DueDayOffset = task.DueDayOffset,
+                AssignmentTarget = task.AssignmentTarget,
+                AcknowledgementRule = task.AcknowledgementRule
+            };
+        }
+    }
+}

--- a/specs/001-journeypoint-platform/tasks.md
+++ b/specs/001-journeypoint-platform/tasks.md
@@ -102,7 +102,7 @@ from markdown, and review document-extracted task proposals.
 - [ ] T020 [P] [US2] Create enrichment entities in `aspnet-core/src/JourneyPoint.Core/Domains/OnboardingPlans/OnboardingDocument.cs` and `ExtractedTask.cs`
 - [x] T021 [US2] Register onboarding `DbSet` properties and mappings in `aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/JourneyPointDbContext.cs` and related configuration files
 - [x] T022 [US2] Add initial onboarding migration under `aspnet-core/src/JourneyPoint.EntityFrameworkCore/Migrations/`
-- [ ] T023 [US2] Implement plan CRUD DTOs and application services in `aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/`
+- [x] T023 [US2] Implement plan CRUD DTOs and application services in `aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/`
 - [ ] T024 [US2] Implement markdown import parsing and draft-save services in `aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/`
 - [ ] T025 [US2] Implement document upload, extraction orchestration, and proposal review services in `aspnet-core/src/JourneyPoint.Application/Services/OnboardingDocumentService/`
 - [ ] T026 [P] [US2] Build facilitator plan pages in `journeypoint/app/(facilitator)/plans/page.tsx`, `journeypoint/app/(facilitator)/plans/[planId]/page.tsx`, and `journeypoint/app/(facilitator)/plans/[planId]/documents/page.tsx`


### PR DESCRIPTION
Linking Issues: #21 
## Summary
- align repo guidance, Spec Kit artifacts, and company standards around the JourneyPoint implementation model
- refactor the onboarding domain and EF persistence foundations to use the stricter typed backend patterns
- add onboarding plan application-service contracts and DTO groundwork for plan CRUD flows
- include related frontend shell cleanup and shared layout refinements made alongside the standards pass

## Testing
- `dotnet build aspnet-core/src/JourneyPoint.Core/JourneyPoint.Core.csproj --no-restore -p:UseSharedCompilation=false`
- `dotnet build aspnet-core/src/JourneyPoint.EntityFrameworkCore/JourneyPoint.EntityFrameworkCore.csproj --no-restore -p:UseSharedCompilation=false`
- `dotnet build aspnet-core/src/JourneyPoint.Application/JourneyPoint.Application.csproj --no-restore -p:UseSharedCompilation=false`