### PR TITLE
feat: Implement markdown import functionality with preview and draft …

### DIFF
--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportPreviewDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportPreviewDto.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService.Dto
+{
+    /// <summary>
+    /// Represents the full markdown import preview returned to facilitators.
+    /// </summary>
+    public class MarkdownImportPreviewDto
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownImportPreviewDto"/> class.
+        /// </summary>
+        public MarkdownImportPreviewDto()
+        {
+            Modules = new List<MarkdownImportPreviewModuleDto>();
+            Warnings = new List<MarkdownImportWarningDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the parsed plan name.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxNameLength)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parsed plan description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parsed target audience.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxTargetAudienceLength)]
+        public string TargetAudience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parsed duration in days.
+        /// </summary>
+        [Range(OnboardingPlan.MinDurationDays, int.MaxValue)]
+        public int DurationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered parsed modules.
+        /// </summary>
+        public List<MarkdownImportPreviewModuleDto> Modules { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parser warnings that require facilitator review.
+        /// </summary>
+        public List<MarkdownImportWarningDto> Warnings { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the preview has enough structure to save as a draft.
+        /// </summary>
+        public bool CanSave { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportPreviewModuleDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportPreviewModuleDto.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService.Dto
+{
+    /// <summary>
+    /// Represents one parsed onboarding module in a markdown import preview.
+    /// </summary>
+    public class MarkdownImportPreviewModuleDto
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownImportPreviewModuleDto"/> class.
+        /// </summary>
+        public MarkdownImportPreviewModuleDto()
+        {
+            Tasks = new List<MarkdownImportPreviewTaskDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the module name.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingModule.MaxNameLength)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingModule.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the plan-local module order index.
+        /// </summary>
+        [Range(OnboardingModule.MinOrderIndex, int.MaxValue)]
+        public int OrderIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered tasks parsed inside the module.
+        /// </summary>
+        public List<MarkdownImportPreviewTaskDto> Tasks { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportPreviewTaskDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportPreviewTaskDto.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService.Dto
+{
+    /// <summary>
+    /// Represents one parsed template task in a markdown import preview.
+    /// </summary>
+    public class MarkdownImportPreviewTaskDto
+    {
+        /// <summary>
+        /// Gets or sets the task title.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingTask.MaxTitleLength)]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingTask.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parsed task category.
+        /// </summary>
+        public OnboardingTaskCategory Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the module-local task order index.
+        /// </summary>
+        [Range(OnboardingTask.MinOrderIndex, int.MaxValue)]
+        public int OrderIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the due-day offset.
+        /// </summary>
+        [Range(OnboardingTask.MinDueDayOffset, int.MaxValue)]
+        public int DueDayOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the assignment target for the task.
+        /// </summary>
+        public OnboardingTaskAssignmentTarget AssignmentTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets the acknowledgement rule for the task.
+        /// </summary>
+        public OnboardingTaskAcknowledgementRule AcknowledgementRule { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportWarningDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/MarkdownImportWarningDto.cs
@@ -1,0 +1,28 @@
+namespace JourneyPoint.Application.Services.MarkdownImportService.Dto
+{
+    /// <summary>
+    /// Represents one parser warning returned during markdown preview.
+    /// </summary>
+    public class MarkdownImportWarningDto
+    {
+        /// <summary>
+        /// Gets or sets the machine-readable warning code.
+        /// </summary>
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Gets or sets the human-readable warning message.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional line number associated with the warning.
+        /// </summary>
+        public int? LineNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional section label associated with the warning.
+        /// </summary>
+        public string SectionName { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/PreviewMarkdownImportRequest.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/PreviewMarkdownImportRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService.Dto
+{
+    /// <summary>
+    /// Defines the input required to preview a structured markdown onboarding import.
+    /// </summary>
+    public class PreviewMarkdownImportRequest
+    {
+        /// <summary>
+        /// Gets or sets the raw markdown content to parse.
+        /// </summary>
+        [Required]
+        public string MarkdownContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional source file name used for fallback naming.
+        /// </summary>
+        [MaxLength(255)]
+        public string SourceFileName { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/SaveMarkdownImportRequest.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/Dto/SaveMarkdownImportRequest.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService.Dto
+{
+    /// <summary>
+    /// Defines the facilitator-approved markdown import payload used to create a draft plan.
+    /// </summary>
+    public class SaveMarkdownImportRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SaveMarkdownImportRequest"/> class.
+        /// </summary>
+        public SaveMarkdownImportRequest()
+        {
+            Modules = new List<MarkdownImportPreviewModuleDto>();
+        }
+
+        /// <summary>
+        /// Gets or sets the draft plan name.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxNameLength)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the draft plan description.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxDescriptionLength)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target audience for the imported draft.
+        /// </summary>
+        [Required]
+        [MaxLength(OnboardingPlan.MaxTargetAudienceLength)]
+        public string TargetAudience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the imported draft duration in days.
+        /// </summary>
+        [Range(OnboardingPlan.MinDurationDays, int.MaxValue)]
+        public int DurationDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered module collection approved by the facilitator.
+        /// </summary>
+        public List<MarkdownImportPreviewModuleDto> Modules { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/IMarkdownImportAppService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/IMarkdownImportAppService.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Abp.Application.Services;
+using JourneyPoint.Application.Services.MarkdownImportService.Dto;
+using JourneyPoint.Application.Services.OnboardingPlanService.Dto;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService
+{
+    /// <summary>
+    /// Defines application-service operations for markdown onboarding import preview and draft save.
+    /// </summary>
+    public interface IMarkdownImportAppService : IApplicationService
+    {
+        /// <summary>
+        /// Parses markdown content into a reviewable onboarding preview.
+        /// </summary>
+        Task<MarkdownImportPreviewDto> PreviewAsync(PreviewMarkdownImportRequest input);
+
+        /// <summary>
+        /// Saves a facilitator-approved markdown preview as a new onboarding draft.
+        /// </summary>
+        Task<OnboardingPlanDetailDto> SaveDraftAsync(SaveMarkdownImportRequest input);
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/MarkdownImportAppService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/MarkdownImportAppService.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Authorization;
+using Abp.Domain.Repositories;
+using Abp.UI;
+using JourneyPoint.Application.Services.MarkdownImportService.Dto;
+using JourneyPoint.Application.Services.OnboardingPlanService.Dto;
+using JourneyPoint.Authorization;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService
+{
+    /// <summary>
+    /// Provides markdown onboarding import preview and draft-save orchestration.
+    /// </summary>
+    [AbpAuthorize(PermissionNames.Pages_JourneyPoint_Facilitator, PermissionNames.Pages_JourneyPoint_TenantAdmin)]
+    public class MarkdownImportAppService : JourneyPointAppServiceBase, IMarkdownImportAppService
+    {
+        private readonly IRepository<OnboardingPlan, Guid> _onboardingPlanRepository;
+        private readonly OnboardingPlanManager _onboardingPlanManager;
+        private readonly MarkdownImportParser _markdownImportParser;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkdownImportAppService"/> class.
+        /// </summary>
+        public MarkdownImportAppService(
+            IRepository<OnboardingPlan, Guid> onboardingPlanRepository,
+            OnboardingPlanManager onboardingPlanManager,
+            MarkdownImportParser markdownImportParser)
+        {
+            _onboardingPlanRepository = onboardingPlanRepository;
+            _onboardingPlanManager = onboardingPlanManager;
+            _markdownImportParser = markdownImportParser;
+        }
+
+        /// <summary>
+        /// Parses markdown content into a reviewable onboarding preview.
+        /// </summary>
+        public Task<MarkdownImportPreviewDto> PreviewAsync(PreviewMarkdownImportRequest input)
+        {
+            var preview = _markdownImportParser.Parse(input.MarkdownContent, input.SourceFileName);
+            return Task.FromResult(preview);
+        }
+
+        /// <summary>
+        /// Saves a facilitator-reviewed markdown preview as a new onboarding draft.
+        /// </summary>
+        public async Task<OnboardingPlanDetailDto> SaveDraftAsync(SaveMarkdownImportRequest input)
+        {
+            if (input == null)
+            {
+                throw new UserFriendlyException("Markdown import content is required before a draft can be saved.");
+            }
+
+            var tenantId = GetRequiredTenantId();
+            var orderedModules = OrderModules(input.Modules).ToList();
+
+            if (!orderedModules.Any())
+            {
+                throw new UserFriendlyException("Add at least one module before saving an imported draft.");
+            }
+
+            var plan = _onboardingPlanManager.CreatePlan(
+                tenantId,
+                input.Name,
+                input.Description,
+                input.TargetAudience,
+                input.DurationDays);
+
+            foreach (var moduleInput in orderedModules)
+            {
+                var module = _onboardingPlanManager.CreateModule(
+                    moduleInput.Name,
+                    moduleInput.Description,
+                    moduleInput.OrderIndex);
+
+                _onboardingPlanManager.AddModule(plan, module);
+
+                foreach (var taskInput in OrderTasks(moduleInput.Tasks))
+                {
+                    var task = _onboardingPlanManager.CreateTask(
+                        taskInput.Title,
+                        taskInput.Description,
+                        taskInput.Category,
+                        taskInput.OrderIndex,
+                        taskInput.DueDayOffset,
+                        taskInput.AssignmentTarget,
+                        taskInput.AcknowledgementRule);
+
+                    _onboardingPlanManager.AddTask(plan, module.Id, task);
+                }
+            }
+
+            await _onboardingPlanRepository.InsertAsync(plan);
+            await CurrentUnitOfWork.SaveChangesAsync();
+
+            return MapToDetailDto(plan);
+        }
+
+        private int GetRequiredTenantId()
+        {
+            if (!AbpSession.TenantId.HasValue)
+            {
+                throw new AbpAuthorizationException("Markdown import requires a tenant context.");
+            }
+
+            return AbpSession.TenantId.Value;
+        }
+
+        private static IEnumerable<MarkdownImportPreviewModuleDto> OrderModules(IEnumerable<MarkdownImportPreviewModuleDto> modules)
+        {
+            return (modules ?? Enumerable.Empty<MarkdownImportPreviewModuleDto>())
+                .OrderBy(module => module.OrderIndex)
+                .ThenBy(module => module.Name);
+        }
+
+        private static IEnumerable<MarkdownImportPreviewTaskDto> OrderTasks(IEnumerable<MarkdownImportPreviewTaskDto> tasks)
+        {
+            return (tasks ?? Enumerable.Empty<MarkdownImportPreviewTaskDto>())
+                .OrderBy(task => task.OrderIndex)
+                .ThenBy(task => task.Title);
+        }
+
+        private static OnboardingPlanDetailDto MapToDetailDto(OnboardingPlan plan)
+        {
+            return new OnboardingPlanDetailDto
+            {
+                Id = plan.Id,
+                Name = plan.Name,
+                Description = plan.Description,
+                TargetAudience = plan.TargetAudience,
+                DurationDays = plan.DurationDays,
+                Status = plan.Status,
+                Modules = plan.Modules
+                    .OrderBy(module => module.OrderIndex)
+                    .Select(MapModuleDto)
+                    .ToList()
+            };
+        }
+
+        private static OnboardingModuleDto MapModuleDto(OnboardingModule module)
+        {
+            return new OnboardingModuleDto
+            {
+                Id = module.Id,
+                Name = module.Name,
+                Description = module.Description,
+                OrderIndex = module.OrderIndex,
+                Tasks = module.Tasks
+                    .OrderBy(task => task.OrderIndex)
+                    .Select(MapTaskDto)
+                    .ToList()
+            };
+        }
+
+        private static OnboardingTaskDto MapTaskDto(OnboardingTask task)
+        {
+            return new OnboardingTaskDto
+            {
+                Id = task.Id,
+                Title = task.Title,
+                Description = task.Description,
+                Category = task.Category,
+                OrderIndex = task.OrderIndex,
+                DueDayOffset = task.DueDayOffset,
+                AssignmentTarget = task.AssignmentTarget,
+                AcknowledgementRule = task.AcknowledgementRule
+            };
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/MarkdownImportParser.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/MarkdownImportParser.cs
@@ -1,0 +1,727 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Abp.Dependency;
+using JourneyPoint.Application.Services.MarkdownImportService.Dto;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.MarkdownImportService
+{
+    /// <summary>
+    /// Parses structured markdown into onboarding preview data and review warnings.
+    /// </summary>
+    public class MarkdownImportParser : ITransientDependency
+    {
+        private const string DefaultPlanName = "Imported Onboarding Plan";
+        private const string DefaultPlanDescription = "Imported from structured markdown.";
+        private const string DefaultTargetAudience = "General Onboarding";
+        private const int DefaultDurationDays = 30;
+        private const string TitleHeaderKey = "title";
+        private const string DescriptionHeaderKey = "description";
+        private const string CategoryHeaderKey = "category";
+        private const string DueDayOffsetHeaderKey = "dueDayOffset";
+        private const string AssignmentTargetHeaderKey = "assignmentTarget";
+        private const string AcknowledgementRuleHeaderKey = "acknowledgementRule";
+
+        /// <summary>
+        /// Parses markdown content into a preview DTO that can be reviewed before save.
+        /// </summary>
+        public MarkdownImportPreviewDto Parse(string markdownContent, string sourceFileName)
+        {
+            if (string.IsNullOrWhiteSpace(markdownContent))
+            {
+                throw new ArgumentException("Markdown content is required.", nameof(markdownContent));
+            }
+
+            var preview = new MarkdownImportPreviewDto();
+            var warnings = new List<MarkdownImportWarningDto>();
+            var lines = markdownContent.Replace("\r\n", "\n").Split('\n');
+            var prefaceLines = new List<string>();
+            var currentModuleDescriptionLines = new List<string>();
+            MarkdownImportPreviewModuleDto currentModule = null;
+            var index = 0;
+
+            while (index < lines.Length)
+            {
+                var trimmedLine = lines[index].Trim();
+
+                if (TryHandleBlankOrPlanTitle(preview, trimmedLine, ref index))
+                {
+                    continue;
+                }
+
+                if (TryStartModule(
+                    preview,
+                    trimmedLine,
+                    currentModule,
+                    currentModuleDescriptionLines,
+                    out currentModule))
+                {
+                    index++;
+                    continue;
+                }
+
+                if (TryHandlePrefaceContent(
+                    preview,
+                    trimmedLine,
+                    warnings,
+                    prefaceLines,
+                    currentModule,
+                    ref index))
+                {
+                    continue;
+                }
+
+                if (TryHandleModuleContent(
+                    lines,
+                    trimmedLine,
+                    currentModule,
+                    currentModuleDescriptionLines,
+                    warnings,
+                    ref index))
+                {
+                    continue;
+                }
+
+                currentModuleDescriptionLines.Add(trimmedLine);
+                index++;
+            }
+
+            FinalizeModuleDescription(currentModule, currentModuleDescriptionLines);
+            ApplyFallbacks(preview, prefaceLines, sourceFileName, warnings);
+            preview.Warnings = warnings;
+            preview.CanSave = CanSave(preview);
+
+            return preview;
+        }
+
+        private static bool TryHandleBlankOrPlanTitle(
+            MarkdownImportPreviewDto preview,
+            string trimmedLine,
+            ref int index)
+        {
+            if (string.IsNullOrWhiteSpace(trimmedLine))
+            {
+                index++;
+                return true;
+            }
+
+            if (!TryApplyPlanTitle(preview, trimmedLine))
+            {
+                return false;
+            }
+
+            index++;
+            return true;
+        }
+
+        private static bool TryHandlePrefaceContent(
+            MarkdownImportPreviewDto preview,
+            string trimmedLine,
+            ICollection<MarkdownImportWarningDto> warnings,
+            List<string> prefaceLines,
+            MarkdownImportPreviewModuleDto currentModule,
+            ref int index)
+        {
+            if (currentModule != null)
+            {
+                return false;
+            }
+
+            if (TryApplyPlanMetadata(preview, trimmedLine, warnings, index + 1))
+            {
+                index++;
+                return true;
+            }
+
+            prefaceLines.Add(trimmedLine);
+            index++;
+            return true;
+        }
+
+        private static bool TryHandleModuleContent(
+            string[] lines,
+            string trimmedLine,
+            MarkdownImportPreviewModuleDto currentModule,
+            List<string> currentModuleDescriptionLines,
+            ICollection<MarkdownImportWarningDto> warnings,
+            ref int index)
+        {
+            if (currentModule == null)
+            {
+                return false;
+            }
+
+            if (IsTableRow(trimmedLine))
+            {
+                FinalizeModuleDescription(currentModule, currentModuleDescriptionLines);
+                currentModuleDescriptionLines.Clear();
+                var rowStartLineNumber = index + 1;
+                var tableLines = ReadTableLines(lines, ref index);
+                ParseTable(currentModule, tableLines, warnings, rowStartLineNumber);
+                return true;
+            }
+
+            if (!trimmedLine.StartsWith("- ", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            FinalizeModuleDescription(currentModule, currentModuleDescriptionLines);
+            currentModuleDescriptionLines.Clear();
+            ParseListTask(currentModule, trimmedLine.Substring(2).Trim(), warnings, index + 1);
+            index++;
+            return true;
+        }
+
+        private static bool TryApplyPlanTitle(MarkdownImportPreviewDto preview, string trimmedLine)
+        {
+            if (!string.IsNullOrWhiteSpace(preview.Name) ||
+                !trimmedLine.StartsWith("# ", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            preview.Name = trimmedLine.Substring(2).Trim();
+            return true;
+        }
+
+        private static bool TryStartModule(
+            MarkdownImportPreviewDto preview,
+            string trimmedLine,
+            MarkdownImportPreviewModuleDto currentModule,
+            List<string> currentModuleDescriptionLines,
+            out MarkdownImportPreviewModuleDto nextModule)
+        {
+            if (!trimmedLine.StartsWith("## ", StringComparison.Ordinal))
+            {
+                nextModule = currentModule;
+                return false;
+            }
+
+            FinalizeModuleDescription(currentModule, currentModuleDescriptionLines);
+            currentModuleDescriptionLines.Clear();
+
+            nextModule = new MarkdownImportPreviewModuleDto
+            {
+                Name = trimmedLine.Substring(3).Trim(),
+                Description = string.Empty,
+                OrderIndex = preview.Modules.Count + 1
+            };
+
+            preview.Modules.Add(nextModule);
+            return true;
+        }
+
+        private static bool TryApplyPlanMetadata(
+            MarkdownImportPreviewDto preview,
+            string line,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber)
+        {
+            if (TryGetMetadataValue(line, "Target Audience", out var targetAudience) ||
+                TryGetMetadataValue(line, "Audience", out targetAudience))
+            {
+                preview.TargetAudience = targetAudience;
+                return true;
+            }
+
+            if (TryGetMetadataValue(line, "Duration Days", out var durationValue) ||
+                TryGetMetadataValue(line, "Duration", out durationValue))
+            {
+                if (int.TryParse(durationValue, out var durationDays) &&
+                    durationDays >= OnboardingPlan.MinDurationDays)
+                {
+                    preview.DurationDays = durationDays;
+                }
+                else
+                {
+                    warnings.Add(CreateWarning(
+                        "InvalidDurationDays",
+                        "Duration days could not be parsed and defaulted to 30.",
+                        lineNumber,
+                        null));
+                }
+
+                return true;
+            }
+
+            if (TryGetMetadataValue(line, "Description", out var description))
+            {
+                preview.Description = description;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetMetadataValue(string line, string label, out string value)
+        {
+            var prefix = $"{label}:";
+
+            if (!line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                value = null;
+                return false;
+            }
+
+            value = line.Substring(prefix.Length).Trim();
+            return true;
+        }
+
+        private static List<string> ReadTableLines(string[] lines, ref int index)
+        {
+            var tableLines = new List<string>();
+
+            while (index < lines.Length && IsTableRow(lines[index].Trim()))
+            {
+                tableLines.Add(lines[index].Trim());
+                index++;
+            }
+
+            return tableLines;
+        }
+
+        private static void ParseTable(
+            MarkdownImportPreviewModuleDto module,
+            IReadOnlyList<string> tableLines,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int startingLineNumber)
+        {
+            if (tableLines.Count < 2)
+            {
+                warnings.Add(CreateWarning(
+                    "IncompleteTable",
+                    "A markdown table was detected but did not contain enough rows to parse tasks.",
+                    startingLineNumber,
+                    module.Name));
+                return;
+            }
+
+            var headerCells = SplitMarkdownRow(tableLines[0]);
+            var headerMap = BuildHeaderMap(headerCells, warnings, startingLineNumber, module.Name);
+
+            if (!headerMap.ContainsKey(TitleHeaderKey))
+            {
+                warnings.Add(CreateWarning(
+                    "MissingTitleColumn",
+                    "Task rows were ignored because no task title column could be identified.",
+                    startingLineNumber,
+                    module.Name));
+                return;
+            }
+
+            for (var rowIndex = 2; rowIndex < tableLines.Count; rowIndex++)
+            {
+                var rowCells = SplitMarkdownRow(tableLines[rowIndex]);
+
+                if (rowCells.Count == 0)
+                {
+                    continue;
+                }
+
+                while (rowCells.Count < headerCells.Count)
+                {
+                    rowCells.Add(string.Empty);
+                }
+
+                var task = CreateTaskFromCells(
+                    rowCells,
+                    headerMap,
+                    warnings,
+                    startingLineNumber + rowIndex,
+                    module.Name,
+                    module.Tasks.Count + 1);
+
+                if (task != null)
+                {
+                    module.Tasks.Add(task);
+                }
+            }
+        }
+
+        private static void ParseListTask(
+            MarkdownImportPreviewModuleDto module,
+            string listContent,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber)
+        {
+            var parts = listContent.Split('|').Select(part => part.Trim()).ToList();
+
+            if (parts.Count < 2)
+            {
+                warnings.Add(CreateWarning(
+                    "InvalidListTaskFormat",
+                    "List-based task rows must include at least a title and description separated by '|'.",
+                    lineNumber,
+                    module.Name));
+                return;
+            }
+
+            module.Tasks.Add(new MarkdownImportPreviewTaskDto
+            {
+                Title = parts[0],
+                Description = parts[1],
+                Category = ParseCategory(parts.ElementAtOrDefault(2), warnings, lineNumber, module.Name),
+                OrderIndex = module.Tasks.Count + 1,
+                DueDayOffset = ParseDueDayOffset(parts.ElementAtOrDefault(3), warnings, lineNumber, module.Name),
+                AssignmentTarget = ParseAssignmentTarget(parts.ElementAtOrDefault(4), warnings, lineNumber, module.Name),
+                AcknowledgementRule = ParseAcknowledgementRule(parts.ElementAtOrDefault(5), warnings, lineNumber, module.Name)
+            });
+        }
+
+        private static Dictionary<string, int> BuildHeaderMap(
+            IReadOnlyList<string> headerCells,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber,
+            string sectionName)
+        {
+            var headerMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            for (var index = 0; index < headerCells.Count; index++)
+            {
+                var normalizedHeader = NormalizeHeader(headerCells[index]);
+
+                if (normalizedHeader == null)
+                {
+                    warnings.Add(CreateWarning(
+                        "UnknownTaskColumn",
+                        $"The column '{headerCells[index]}' is not recognised and will be ignored.",
+                        lineNumber,
+                        sectionName));
+                    continue;
+                }
+
+                if (!headerMap.ContainsKey(normalizedHeader))
+                {
+                    headerMap.Add(normalizedHeader, index);
+                }
+            }
+
+            return headerMap;
+        }
+
+        private static MarkdownImportPreviewTaskDto CreateTaskFromCells(
+            IReadOnlyList<string> rowCells,
+            IReadOnlyDictionary<string, int> headerMap,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber,
+            string sectionName,
+            int orderIndex)
+        {
+            var title = GetCell(rowCells, headerMap, TitleHeaderKey);
+            var description = GetCell(rowCells, headerMap, DescriptionHeaderKey);
+
+            if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(description))
+            {
+                warnings.Add(CreateWarning(
+                    "EmptyTaskRow",
+                    "A task row was ignored because both title and description were empty.",
+                    lineNumber,
+                    sectionName));
+                return null;
+            }
+
+            return new MarkdownImportPreviewTaskDto
+            {
+                Title = title ?? string.Empty,
+                Description = description ?? string.Empty,
+                Category = ParseCategory(GetCell(rowCells, headerMap, CategoryHeaderKey), warnings, lineNumber, sectionName),
+                OrderIndex = orderIndex,
+                DueDayOffset = ParseDueDayOffset(GetCell(rowCells, headerMap, DueDayOffsetHeaderKey), warnings, lineNumber, sectionName),
+                AssignmentTarget = ParseAssignmentTarget(GetCell(rowCells, headerMap, AssignmentTargetHeaderKey), warnings, lineNumber, sectionName),
+                AcknowledgementRule = ParseAcknowledgementRule(GetCell(rowCells, headerMap, AcknowledgementRuleHeaderKey), warnings, lineNumber, sectionName)
+            };
+        }
+
+        private static string GetCell(
+            IReadOnlyList<string> rowCells,
+            IReadOnlyDictionary<string, int> headerMap,
+            string key)
+        {
+            return headerMap.TryGetValue(key, out var index) && index < rowCells.Count
+                ? rowCells[index]
+                : null;
+        }
+
+        private static OnboardingTaskCategory ParseCategory(
+            string value,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber,
+            string sectionName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return OnboardingTaskCategory.Orientation;
+            }
+
+            var normalizedValue = value.Replace("-", string.Empty).Replace(" ", string.Empty);
+
+            if (Enum.TryParse(normalizedValue, true, out OnboardingTaskCategory category))
+            {
+                return category;
+            }
+
+            warnings.Add(CreateWarning(
+                "InvalidTaskCategory",
+                $"The task category '{value}' was not recognised and defaulted to Orientation.",
+                lineNumber,
+                sectionName));
+
+            return OnboardingTaskCategory.Orientation;
+        }
+
+        private static int ParseDueDayOffset(
+            string value,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber,
+            string sectionName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return 0;
+            }
+
+            if (int.TryParse(value, out var dueDayOffset) &&
+                dueDayOffset >= OnboardingTask.MinDueDayOffset)
+            {
+                return dueDayOffset;
+            }
+
+            warnings.Add(CreateWarning(
+                "InvalidDueDayOffset",
+                $"The due day offset '{value}' was not recognised and defaulted to 0.",
+                lineNumber,
+                sectionName));
+
+            return 0;
+        }
+
+        private static OnboardingTaskAssignmentTarget ParseAssignmentTarget(
+            string value,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber,
+            string sectionName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return OnboardingTaskAssignmentTarget.Enrolee;
+            }
+
+            var normalizedValue = value.Replace("-", string.Empty).Replace(" ", string.Empty);
+
+            if (Enum.TryParse(normalizedValue, true, out OnboardingTaskAssignmentTarget assignmentTarget))
+            {
+                return assignmentTarget;
+            }
+
+            warnings.Add(CreateWarning(
+                "InvalidAssignmentTarget",
+                $"The assignment target '{value}' was not recognised and defaulted to Enrolee.",
+                lineNumber,
+                sectionName));
+
+            return OnboardingTaskAssignmentTarget.Enrolee;
+        }
+
+        private static OnboardingTaskAcknowledgementRule ParseAcknowledgementRule(
+            string value,
+            ICollection<MarkdownImportWarningDto> warnings,
+            int lineNumber,
+            string sectionName)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return OnboardingTaskAcknowledgementRule.NotRequired;
+            }
+
+            var normalizedValue = value.Replace("-", string.Empty).Replace(" ", string.Empty);
+
+            if (normalizedValue.Equals("Yes", StringComparison.OrdinalIgnoreCase) ||
+                normalizedValue.Equals("True", StringComparison.OrdinalIgnoreCase))
+            {
+                return OnboardingTaskAcknowledgementRule.Required;
+            }
+
+            if (normalizedValue.Equals("No", StringComparison.OrdinalIgnoreCase) ||
+                normalizedValue.Equals("False", StringComparison.OrdinalIgnoreCase))
+            {
+                return OnboardingTaskAcknowledgementRule.NotRequired;
+            }
+
+            if (Enum.TryParse(normalizedValue, true, out OnboardingTaskAcknowledgementRule acknowledgementRule))
+            {
+                return acknowledgementRule;
+            }
+
+            warnings.Add(CreateWarning(
+                "InvalidAcknowledgementRule",
+                $"The acknowledgement rule '{value}' was not recognised and defaulted to NotRequired.",
+                lineNumber,
+                sectionName));
+
+            return OnboardingTaskAcknowledgementRule.NotRequired;
+        }
+
+        private static void ApplyFallbacks(
+            MarkdownImportPreviewDto preview,
+            IReadOnlyCollection<string> prefaceLines,
+            string sourceFileName,
+            ICollection<MarkdownImportWarningDto> warnings)
+        {
+            if (string.IsNullOrWhiteSpace(preview.Name))
+            {
+                preview.Name = string.IsNullOrWhiteSpace(sourceFileName)
+                    ? DefaultPlanName
+                    : Path.GetFileNameWithoutExtension(sourceFileName);
+
+                warnings.Add(CreateWarning(
+                    "MissingPlanTitle",
+                    "No top-level markdown title was found, so the plan name was derived from the file name or a default label.",
+                    null,
+                    null));
+            }
+
+            if (string.IsNullOrWhiteSpace(preview.Description))
+            {
+                preview.Description = prefaceLines.Any()
+                    ? string.Join(Environment.NewLine, prefaceLines)
+                    : DefaultPlanDescription;
+
+                warnings.Add(CreateWarning(
+                    "MissingPlanDescription",
+                    "No explicit plan description was found, so a default or preface summary was used.",
+                    null,
+                    null));
+            }
+
+            if (string.IsNullOrWhiteSpace(preview.TargetAudience))
+            {
+                preview.TargetAudience = DefaultTargetAudience;
+                warnings.Add(CreateWarning(
+                    "MissingTargetAudience",
+                    "No target audience was found, so the preview defaulted to General Onboarding.",
+                    null,
+                    null));
+            }
+
+            if (preview.DurationDays < OnboardingPlan.MinDurationDays)
+            {
+                preview.DurationDays = DefaultDurationDays;
+                warnings.Add(CreateWarning(
+                    "MissingDurationDays",
+                    "No valid duration was found, so the preview defaulted to 30 days.",
+                    null,
+                    null));
+            }
+
+            if (!preview.Modules.Any())
+            {
+                warnings.Add(CreateWarning(
+                    "NoModulesDetected",
+                    "No module headings were detected. Add '## Module Name' sections before saving a draft.",
+                    null,
+                    null));
+            }
+        }
+
+        private static bool CanSave(MarkdownImportPreviewDto preview)
+        {
+            return !string.IsNullOrWhiteSpace(preview.Name)
+                && !string.IsNullOrWhiteSpace(preview.Description)
+                && !string.IsNullOrWhiteSpace(preview.TargetAudience)
+                && preview.DurationDays >= OnboardingPlan.MinDurationDays
+                && preview.Modules.Any()
+                && preview.Modules.All(module => !string.IsNullOrWhiteSpace(module.Name))
+                && preview.Modules.All(module => !string.IsNullOrWhiteSpace(module.Description))
+                && preview.Modules.All(module => module.Tasks.All(task =>
+                    !string.IsNullOrWhiteSpace(task.Title) &&
+                    !string.IsNullOrWhiteSpace(task.Description)));
+        }
+
+        private static void FinalizeModuleDescription(
+            MarkdownImportPreviewModuleDto module,
+            IReadOnlyCollection<string> descriptionLines)
+        {
+            if (module == null)
+            {
+                return;
+            }
+
+            module.Description = descriptionLines.Any()
+                ? string.Join(Environment.NewLine, descriptionLines)
+                : "Imported module description pending review.";
+        }
+
+        private static bool IsTableRow(string line)
+        {
+            return !string.IsNullOrWhiteSpace(line) && line[0] == '|';
+        }
+
+        private static string NormalizeHeader(string headerCell)
+        {
+            var normalizedHeader = headerCell
+                .Trim()
+                .ToLowerInvariant()
+                .Replace("-", string.Empty)
+                .Replace(" ", string.Empty);
+
+            switch (normalizedHeader)
+            {
+                case TitleHeaderKey:
+                case "task":
+                case "tasktitle":
+                    return TitleHeaderKey;
+                case DescriptionHeaderKey:
+                case "details":
+                case "taskdescription":
+                    return DescriptionHeaderKey;
+                case "category":
+                case "type":
+                    return CategoryHeaderKey;
+                case "duedayoffset":
+                case "dayoffset":
+                case "duedays":
+                case "due":
+                    return DueDayOffsetHeaderKey;
+                case "assignmenttarget":
+                case "assignedto":
+                case "owner":
+                    return AssignmentTargetHeaderKey;
+                case "acknowledgement":
+                case "acknowledgementrule":
+                case "acknowledgment":
+                case "ack":
+                    return AcknowledgementRuleHeaderKey;
+                default:
+                    return null;
+            }
+        }
+
+        private static List<string> SplitMarkdownRow(string row)
+        {
+            return row
+                .Trim()
+                .Trim('|')
+                .Split('|')
+                .Select(cell => cell.Trim())
+                .ToList();
+        }
+
+        private static MarkdownImportWarningDto CreateWarning(
+            string code,
+            string message,
+            int? lineNumber,
+            string sectionName)
+        {
+            return new MarkdownImportWarningDto
+            {
+                Code = code,
+                Message = message,
+                LineNumber = lineNumber,
+                SectionName = sectionName
+            };
+        }
+    }
+}

--- a/journeypoint/app/(facilitator)/facilitator/markdown-import/page.tsx
+++ b/journeypoint/app/(facilitator)/facilitator/markdown-import/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import React from "react";
+import {
+    APP_PERMISSIONS,
+    APP_ROLE_NAMES,
+} from "@/constants/auth/permissions";
+import MarkdownImportWorkspace from "@/components/plans/MarkdownImportWorkspace";
+import withAuth from "@/hoc/withAuth";
+import { MarkdownImportProvider } from "@/providers/markdownImportProvider";
+
+const FacilitatorMarkdownImportPage: React.FC = () => (
+    <MarkdownImportProvider>
+        <MarkdownImportWorkspace />
+    </MarkdownImportProvider>
+);
+
+export default withAuth(FacilitatorMarkdownImportPage, {
+    requiredPermission: APP_PERMISSIONS.facilitator,
+    allowedRoles: [APP_ROLE_NAMES.facilitator],
+});

--- a/journeypoint/components/plans/MarkdownImportWarnings.tsx
+++ b/journeypoint/components/plans/MarkdownImportWarnings.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+import { Alert } from "antd";
+import { useStyles } from "@/components/plans/style/style";
+import type { IMarkdownImportWarningDto } from "@/types/markdown-import";
+
+interface IMarkdownImportWarningsProps {
+    warnings: IMarkdownImportWarningDto[];
+}
+
+const buildWarningMessage = (warning: IMarkdownImportWarningDto): string => {
+    const locationParts = [
+        warning.sectionName ? `Section: ${warning.sectionName}` : null,
+        warning.lineNumber ? `Line: ${warning.lineNumber}` : null,
+    ].filter(Boolean);
+
+    return locationParts.length > 0
+        ? `${warning.message} (${locationParts.join(" | ")})`
+        : warning.message;
+};
+
+/**
+ * Renders parser warnings that require facilitator review before save.
+ */
+const MarkdownImportWarnings: React.FC<IMarkdownImportWarningsProps> = ({
+    warnings,
+}) => {
+    const { styles } = useStyles();
+
+    if (warnings.length === 0) {
+        return null;
+    }
+
+    return (
+        <Alert
+            className={styles.alert}
+            type="warning"
+            showIcon
+            title="Review parser warnings before saving the imported draft."
+            description={
+                <ul className={styles.warningsList}>
+                    {warnings.map((warning, index) => (
+                        <li key={`${warning.code}-${index}`}>
+                            {buildWarningMessage(warning)}
+                        </li>
+                    ))}
+                </ul>
+            }
+        />
+    );
+};
+
+export default MarkdownImportWarnings;

--- a/journeypoint/components/plans/MarkdownImportWorkspace.tsx
+++ b/journeypoint/components/plans/MarkdownImportWorkspace.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import React, {
+    startTransition,
+    useEffect,
+    useEffectEvent,
+    useMemo,
+    useState,
+} from "react";
+import {
+    Alert,
+    Button,
+    Card,
+    Empty,
+    Input,
+    InputNumber,
+    Space,
+    Typography,
+    Upload,
+    message,
+} from "antd";
+import type { UploadProps } from "antd";
+import {
+    EyeOutlined,
+    InboxOutlined,
+    RollbackOutlined,
+    SaveOutlined,
+} from "@ant-design/icons";
+import {
+    APP_ROUTES,
+    buildFacilitatorPlanRoute,
+} from "@/constants/auth/routes";
+import MarkdownPreviewTable from "@/components/plans/MarkdownPreviewTable";
+import MarkdownImportWarnings from "@/components/plans/MarkdownImportWarnings";
+import TaskFormModal from "@/components/plans/TaskFormModal";
+import { useStyles } from "@/components/plans/style/style";
+import {
+    useMarkdownImportActions,
+    useMarkdownImportState,
+} from "@/providers/markdownImportProvider";
+import type {
+    IOnboardingPlanDraft,
+    IOnboardingTaskDraft,
+    IOnboardingTaskEditorValues,
+} from "@/types/onboarding-plan";
+import { useRouter } from "next/navigation";
+
+const { Paragraph, Text, Title } = Typography;
+
+const SAMPLE_MARKDOWN = `# Graduate Cohort Programme
+Description: Multi-week onboarding for the graduate cohort.
+Target Audience: Graduate hires
+Duration Days: 21
+
+## Week 1 - Orientation
+Welcome activities and first-day setup.
+
+| Title | Description | Category | Due | Assigned To | Acknowledgement |
+| --- | --- | --- | --- | --- | --- |
+| Collect laptop | Confirm device handover and login credentials. | Orientation | 0 | Facilitator | Required |
+| Meet your manager | Introductory session with the line manager. | CheckIn | 1 | Manager | Not Required |
+`;
+
+interface ITaskModalState {
+    moduleClientKey: string;
+    taskClientKey: string;
+}
+
+const findDraftTask = (
+    draftPlan: IOnboardingPlanDraft | null | undefined,
+    moduleClientKey: string | null,
+    taskClientKey: string | null,
+): IOnboardingTaskDraft | null => {
+    if (!draftPlan || !moduleClientKey || !taskClientKey) {
+        return null;
+    }
+
+    const parentModule = draftPlan.modules.find(
+        (module) => module.clientKey === moduleClientKey,
+    );
+
+    return parentModule?.tasks.find((task) => task.clientKey === taskClientKey) ?? null;
+};
+
+/**
+ * Provides the facilitator markdown import review and draft-save workspace.
+ */
+const MarkdownImportWorkspace: React.FC = () => {
+    const { styles } = useStyles();
+    const router = useRouter();
+    const [messageApi, messageContextHolder] = message.useMessage();
+    const {
+        previewImport,
+        removePreviewModule,
+        removePreviewTask,
+        resetImport,
+        saveDraft,
+        setPreviewMetadata,
+        setSourceContent,
+        updatePreviewModule,
+        updatePreviewTask,
+    } = useMarkdownImportActions();
+    const {
+        isPreviewPending,
+        isSavePending,
+        previewPlan,
+        sourceContent,
+        sourceFileName,
+    } = useMarkdownImportState();
+    const [taskModalState, setTaskModalState] = useState<ITaskModalState | null>(
+        null,
+    );
+
+    const resetWorkspace = useEffectEvent((): void => {
+        resetImport();
+    });
+
+    useEffect(() => {
+        resetWorkspace();
+
+        return () => {
+            resetWorkspace();
+        };
+    }, []);
+
+    const editingTask = useMemo(
+        () =>
+            findDraftTask(
+                previewPlan?.plan,
+                taskModalState?.moduleClientKey ?? null,
+                taskModalState?.taskClientKey ?? null,
+            ),
+        [previewPlan?.plan, taskModalState],
+    );
+
+    const handlePreview = async (): Promise<void> => {
+        if (!sourceContent.trim()) {
+            messageApi.error("Paste markdown content or upload a markdown file first.");
+            return;
+        }
+
+        const preview = await previewImport();
+
+        if (!preview) {
+            messageApi.error("The markdown content could not be parsed.");
+            return;
+        }
+
+        if (preview.warnings.length > 0) {
+            messageApi.warning("Preview generated with warnings. Review the parsed content before saving.");
+            return;
+        }
+
+        messageApi.success("Preview generated.");
+    };
+
+    const handleSaveDraft = async (): Promise<void> => {
+        if (!previewPlan?.plan) {
+            messageApi.error("Generate and review a preview before saving a draft.");
+            return;
+        }
+
+        if (!previewPlan.canSave) {
+            messageApi.error("Resolve the preview issues before saving the draft.");
+            return;
+        }
+
+        const savedPlan = await saveDraft();
+
+        if (!savedPlan) {
+            messageApi.error("The imported onboarding draft could not be saved.");
+            return;
+        }
+
+        messageApi.success("Draft plan created.");
+        startTransition(() => {
+            router.push(buildFacilitatorPlanRoute(savedPlan.id));
+        });
+    };
+
+    const handleTaskSubmit = async (
+        values: IOnboardingTaskEditorValues,
+    ): Promise<void> => {
+        if (!taskModalState) {
+            return;
+        }
+
+        updatePreviewTask(
+            taskModalState.moduleClientKey,
+            taskModalState.taskClientKey,
+            values,
+        );
+        setTaskModalState(null);
+    };
+
+    const handleLoadExample = (): void => {
+        setSourceContent(SAMPLE_MARKDOWN, "sample-onboarding-plan.md");
+    };
+
+    const uploadProps: UploadProps = {
+        accept: ".md,.markdown,text/markdown,text/plain",
+        showUploadList: false,
+        beforeUpload: async (file) => {
+            const content = await file.text();
+            setSourceContent(content, file.name);
+            messageApi.success(`${file.name} loaded for preview.`);
+            return Upload.LIST_IGNORE;
+        },
+    };
+
+    return (
+        <Space orientation="vertical" size={24} className={styles.pageRoot}>
+            {messageContextHolder}
+            <div className={styles.pageHeader}>
+                <div>
+                    <Title level={2} className={styles.pageHeading}>
+                        Import Markdown
+                    </Title>
+                    <Paragraph type="secondary">
+                        Parse structured markdown into a reviewable onboarding draft.
+                        Nothing is applied automatically. A facilitator must inspect
+                        and approve the preview before the draft is created.
+                    </Paragraph>
+                </div>
+
+                <Space wrap className={styles.pageActions}>
+                    <Button
+                        icon={<RollbackOutlined />}
+                        onClick={() =>
+                            startTransition(() =>
+                                router.push(APP_ROUTES.facilitatorPlans),
+                            )
+                        }
+                    >
+                        Back to Plans
+                    </Button>
+                    <Button onClick={handleLoadExample}>Load Example</Button>
+                    <Button onClick={resetImport}>Reset</Button>
+                    <Button
+                        icon={<EyeOutlined />}
+                        onClick={() => void handlePreview()}
+                        loading={isPreviewPending}
+                        type="primary"
+                    >
+                        Preview Import
+                    </Button>
+                    <Button
+                        icon={<SaveOutlined />}
+                        onClick={() => void handleSaveDraft()}
+                        loading={isSavePending}
+                        disabled={!previewPlan?.plan || !previewPlan.canSave}
+                    >
+                        Save Draft
+                    </Button>
+                </Space>
+            </div>
+
+            <Alert
+                className={styles.alert}
+                type="info"
+                showIcon
+                title="Accepted markdown content only affects future journeys once this draft is later used for enrolment."
+            />
+
+            <div className={styles.importGrid}>
+                <Card className={styles.importSourceCard}>
+                    <Space orientation="vertical" size={16} className={styles.pageRoot}>
+                        <div>
+                            <Title level={4}>Source Markdown</Title>
+                            <Paragraph type="secondary">
+                                Use a top-level plan title, optional metadata fields,
+                                `##` module headings, and either markdown task tables
+                                or list rows separated with `|`.
+                            </Paragraph>
+                        </div>
+
+                        <Upload.Dragger {...uploadProps}>
+                            <p className="ant-upload-drag-icon">
+                                <InboxOutlined />
+                            </p>
+                            <p className="ant-upload-text">
+                                Drop a markdown file here or click to load one.
+                            </p>
+                            <p className="ant-upload-hint">
+                                Review is mandatory before any draft is created.
+                            </p>
+                        </Upload.Dragger>
+
+                        {sourceFileName ? (
+                            <Text type="secondary">Loaded file: {sourceFileName}</Text>
+                        ) : null}
+
+                        <Input.TextArea
+                            className={styles.importTextArea}
+                            value={sourceContent}
+                            onChange={(event) =>
+                                setSourceContent(event.target.value, sourceFileName)
+                            }
+                            placeholder="Paste structured markdown here."
+                            rows={18}
+                        />
+                    </Space>
+                </Card>
+
+                <Card className={styles.importPreviewCard}>
+                    <Space orientation="vertical" size={16} className={styles.pageRoot}>
+                        <div>
+                            <Title level={4}>Preview and Review</Title>
+                            <Paragraph type="secondary">
+                                Edit the parsed metadata, remove bad rows, and fix task
+                                content before saving the import as a draft plan.
+                            </Paragraph>
+                        </div>
+
+                        {previewPlan?.plan ? (
+                            <>
+                                <div className={styles.metadataGrid}>
+                                    <Input
+                                        value={previewPlan.plan.name}
+                                        onChange={(event) =>
+                                            setPreviewMetadata({
+                                                name: event.target.value,
+                                            })
+                                        }
+                                        placeholder="Plan name"
+                                        maxLength={200}
+                                    />
+                                    <Input
+                                        value={previewPlan.plan.targetAudience}
+                                        onChange={(event) =>
+                                            setPreviewMetadata({
+                                                targetAudience: event.target.value,
+                                            })
+                                        }
+                                        placeholder="Target audience"
+                                        maxLength={200}
+                                    />
+                                    <InputNumber
+                                        min={1}
+                                        precision={0}
+                                        value={previewPlan.plan.durationDays}
+                                        onChange={(value) =>
+                                            setPreviewMetadata({
+                                                durationDays: value ?? 1,
+                                            })
+                                        }
+                                    />
+                                    <Input value="Draft preview" disabled />
+                                    <Input.TextArea
+                                        className={styles.fullWidthField}
+                                        value={previewPlan.plan.description}
+                                        onChange={(event) =>
+                                            setPreviewMetadata({
+                                                description: event.target.value,
+                                            })
+                                        }
+                                        placeholder="Plan description"
+                                        rows={5}
+                                        maxLength={4000}
+                                    />
+                                </div>
+
+                                <MarkdownImportWarnings
+                                    warnings={previewPlan.warnings}
+                                />
+
+                                {previewPlan.canSave ? null : (
+                                    <Alert
+                                        className={styles.alert}
+                                        type="warning"
+                                        showIcon
+                                        title="This preview still has missing required values. Resolve the highlighted issues before saving."
+                                    />
+                                )}
+
+                                <MarkdownPreviewTable
+                                    modules={previewPlan.plan.modules}
+                                    onEditTask={(moduleClientKey, taskClientKey) =>
+                                        setTaskModalState({
+                                            moduleClientKey,
+                                            taskClientKey,
+                                        })
+                                    }
+                                    onModuleChange={updatePreviewModule}
+                                    onRemoveModule={removePreviewModule}
+                                    onRemoveTask={removePreviewTask}
+                                />
+                            </>
+                        ) : (
+                            <Empty
+                                className={styles.emptyState}
+                                description="Generate a preview to review parsed plan content."
+                            />
+                        )}
+                    </Space>
+                </Card>
+            </div>
+
+            <TaskFormModal
+                editingTask={editingTask}
+                isPending={isSavePending}
+                isVisible={taskModalState !== null}
+                onCancel={() => setTaskModalState(null)}
+                onSubmit={handleTaskSubmit}
+            />
+        </Space>
+    );
+};
+
+export default MarkdownImportWorkspace;

--- a/journeypoint/components/plans/MarkdownPreviewTable.tsx
+++ b/journeypoint/components/plans/MarkdownPreviewTable.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import React from "react";
+import { Button, Card, Input, Space, Table, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import type {
+    IOnboardingModuleDraft,
+    IOnboardingTaskDraft,
+} from "@/types/onboarding-plan";
+import {
+    ONBOARDING_TASK_ACKNOWLEDGEMENT_RULE_OPTIONS,
+    ONBOARDING_TASK_ASSIGNMENT_TARGET_OPTIONS,
+    ONBOARDING_TASK_CATEGORY_OPTIONS,
+} from "@/types/onboarding-plan";
+import { useStyles } from "@/components/plans/style/style";
+
+const { Paragraph, Title } = Typography;
+
+const findOptionLabel = (
+    options: ReadonlyArray<{ label: string; value: number }>,
+    value: number,
+): string => options.find((option) => option.value === value)?.label ?? "Unknown";
+
+interface IMarkdownPreviewTableProps {
+    modules: IOnboardingModuleDraft[];
+    onEditTask: (moduleClientKey: string, taskClientKey: string) => void;
+    onModuleChange: (
+        moduleClientKey: string,
+        name: string,
+        description: string,
+    ) => void;
+    onRemoveModule: (moduleClientKey: string) => void;
+    onRemoveTask: (moduleClientKey: string, taskClientKey: string) => void;
+}
+
+interface IMarkdownPreviewTaskRow extends IOnboardingTaskDraft {
+    key: string;
+    moduleClientKey: string;
+}
+
+/**
+ * Renders editable markdown-import preview modules and parsed task rows.
+ */
+const MarkdownPreviewTable: React.FC<IMarkdownPreviewTableProps> = ({
+    modules,
+    onEditTask,
+    onModuleChange,
+    onRemoveModule,
+    onRemoveTask,
+}) => {
+    const { styles } = useStyles();
+
+    const columns: ColumnsType<IMarkdownPreviewTaskRow> = [
+        {
+            title: "Title",
+            dataIndex: "title",
+            key: "title",
+        },
+        {
+            title: "Category",
+            dataIndex: "category",
+            key: "category",
+            render: (value: number) =>
+                findOptionLabel(ONBOARDING_TASK_CATEGORY_OPTIONS, value),
+        },
+        {
+            title: "Due Offset",
+            dataIndex: "dueDayOffset",
+            key: "dueDayOffset",
+            render: (value: number) => `${value} days`,
+        },
+        {
+            title: "Assigned To",
+            dataIndex: "assignmentTarget",
+            key: "assignmentTarget",
+            render: (value: number) =>
+                findOptionLabel(ONBOARDING_TASK_ASSIGNMENT_TARGET_OPTIONS, value),
+        },
+        {
+            title: "Acknowledgement",
+            dataIndex: "acknowledgementRule",
+            key: "acknowledgementRule",
+            render: (value: number) =>
+                findOptionLabel(
+                    ONBOARDING_TASK_ACKNOWLEDGEMENT_RULE_OPTIONS,
+                    value,
+                ),
+        },
+        {
+            title: "Actions",
+            key: "actions",
+            render: (_, task) => (
+                <Space wrap>
+                    <Button onClick={() => onEditTask(task.moduleClientKey, task.clientKey)}>
+                        Edit
+                    </Button>
+                    <Button
+                        danger
+                        onClick={() => onRemoveTask(task.moduleClientKey, task.clientKey)}
+                    >
+                        Remove
+                    </Button>
+                </Space>
+            ),
+        },
+    ];
+
+    return (
+        <Space orientation="vertical" size={16} className={styles.modulesWrap}>
+            {modules.map((module) => {
+                const tableData: IMarkdownPreviewTaskRow[] = module.tasks.map((task) => ({
+                    ...task,
+                    key: task.clientKey,
+                    moduleClientKey: module.clientKey,
+                }));
+
+                return (
+                    <Card key={module.clientKey} className={styles.previewModuleCard}>
+                        <Space orientation="vertical" size={16} className={styles.modulesWrap}>
+                            <div className={styles.moduleHeader}>
+                                <div>
+                                    <Title level={4}>Module {module.orderIndex}</Title>
+                                    <Paragraph type="secondary">
+                                        Review parsed values before creating the draft.
+                                    </Paragraph>
+                                </div>
+
+                                <Button
+                                    danger
+                                    onClick={() => onRemoveModule(module.clientKey)}
+                                >
+                                    Remove Module
+                                </Button>
+                            </div>
+
+                            <Input
+                                value={module.name}
+                                onChange={(event) =>
+                                    onModuleChange(
+                                        module.clientKey,
+                                        event.target.value,
+                                        module.description,
+                                    )
+                                }
+                                placeholder="Module name"
+                                maxLength={200}
+                            />
+
+                            <Input.TextArea
+                                value={module.description}
+                                onChange={(event) =>
+                                    onModuleChange(
+                                        module.clientKey,
+                                        module.name,
+                                        event.target.value,
+                                    )
+                                }
+                                placeholder="Module description"
+                                rows={4}
+                                maxLength={2000}
+                            />
+
+                            <div className={styles.previewTableWrap}>
+                                <Table<IMarkdownPreviewTaskRow>
+                                    columns={columns}
+                                    dataSource={tableData}
+                                    pagination={false}
+                                    rowKey="clientKey"
+                                />
+                            </div>
+                        </Space>
+                    </Card>
+                );
+            })}
+        </Space>
+    );
+};
+
+export default MarkdownPreviewTable;

--- a/journeypoint/components/plans/PlanCard.tsx
+++ b/journeypoint/components/plans/PlanCard.tsx
@@ -54,6 +54,15 @@ const PlanCard: React.FC<IPlanCardProps> = ({
     const { styles } = useStyles();
     const canPublish = plan.status === OnboardingPlanStatus.Draft;
     const canArchive = plan.status !== OnboardingPlanStatus.Archived;
+    const handleCloneClick = async (): Promise<void> => {
+        await onClone(plan);
+    };
+    const handlePublishClick = async (): Promise<void> => {
+        await onPublish(plan);
+    };
+    const handleArchiveClick = async (): Promise<void> => {
+        await onArchive(plan);
+    };
 
     return (
         <Card className={styles.planCard}>
@@ -92,12 +101,12 @@ const PlanCard: React.FC<IPlanCardProps> = ({
 
                 <Space wrap className={styles.planCardActions}>
                     <Button onClick={() => onOpen(plan.id)}>Open</Button>
-                    <Button onClick={() => void onClone(plan)} loading={isActionPending}>
+                    <Button onClick={handleCloneClick} loading={isActionPending}>
                         Clone
                     </Button>
                     <Button
                         type="primary"
-                        onClick={() => void onPublish(plan)}
+                        onClick={handlePublishClick}
                         disabled={!canPublish}
                         loading={isActionPending}
                     >
@@ -105,7 +114,7 @@ const PlanCard: React.FC<IPlanCardProps> = ({
                     </Button>
                     <Button
                         danger
-                        onClick={() => void onArchive(plan)}
+                        onClick={handleArchiveClick}
                         disabled={!canArchive}
                         loading={isActionPending}
                     >

--- a/journeypoint/components/plans/PlanListView.tsx
+++ b/journeypoint/components/plans/PlanListView.tsx
@@ -13,8 +13,11 @@ import {
     Typography,
     message,
 } from "antd";
-import { PlusOutlined, ReloadOutlined } from "@ant-design/icons";
-import { buildFacilitatorPlanRoute } from "@/constants/auth/routes";
+import { ImportOutlined, PlusOutlined, ReloadOutlined } from "@ant-design/icons";
+import {
+    APP_ROUTES,
+    buildFacilitatorPlanRoute,
+} from "@/constants/auth/routes";
 import PlanCard from "@/components/plans/PlanCard";
 import { useStyles } from "@/components/plans/style/style";
 import {
@@ -151,9 +154,49 @@ const PlanListView: React.FC = () => {
     };
 
     const hasPlans = (plans ?? []).length > 0;
+    const listContent = isListPending ? (
+        <Spin size="large" className={styles.loadingWrap} />
+    ) : hasPlans ? (
+        <>
+            <div className={styles.planGrid}>
+                {(plans ?? []).map((plan) => (
+                    <PlanCard
+                        key={plan.id}
+                        isActionPending={isMutationPending}
+                        onArchive={handleArchive}
+                        onClone={handleClone}
+                        onOpen={handleOpen}
+                        onPublish={handlePublish}
+                        plan={plan}
+                    />
+                ))}
+            </div>
+
+            <div className={styles.paginationWrap}>
+                <Pagination
+                    current={query.current}
+                    pageSize={query.maxResultCount}
+                    total={totalCount ?? 0}
+                    showSizeChanger
+                    onChange={(page, pageSize) =>
+                        setQuery((currentQuery) => ({
+                            ...currentQuery,
+                            current: page,
+                            maxResultCount: pageSize,
+                        }))
+                    }
+                />
+            </div>
+        </>
+    ) : (
+        <Empty
+            className={styles.emptyState}
+            description="No onboarding plans match the current filter set."
+        />
+    );
 
     return (
-        <Space direction="vertical" size={24} className={styles.pageRoot}>
+        <Space orientation="vertical" size={24} className={styles.pageRoot}>
             {messageContextHolder}
             <div className={styles.pageHeader}>
                 <div>
@@ -181,6 +224,16 @@ const PlanListView: React.FC = () => {
                         onClick={() => handleOpen("new")}
                     >
                         New Plan
+                    </Button>
+                    <Button
+                        icon={<ImportOutlined />}
+                        onClick={() =>
+                            startTransition(() =>
+                                router.push(APP_ROUTES.facilitatorMarkdownImport),
+                            )
+                        }
+                    >
+                        Import Markdown
                     </Button>
                 </Space>
             </div>
@@ -215,46 +268,7 @@ const PlanListView: React.FC = () => {
                 </div>
             </Card>
 
-            {isListPending ? (
-                <Spin size="large" className={styles.loadingWrap} />
-            ) : hasPlans ? (
-                <>
-                    <div className={styles.planGrid}>
-                        {(plans ?? []).map((plan) => (
-                            <PlanCard
-                                key={plan.id}
-                                isActionPending={isMutationPending}
-                                onArchive={handleArchive}
-                                onClone={handleClone}
-                                onOpen={handleOpen}
-                                onPublish={handlePublish}
-                                plan={plan}
-                            />
-                        ))}
-                    </div>
-
-                    <div className={styles.paginationWrap}>
-                        <Pagination
-                            current={query.current}
-                            pageSize={query.maxResultCount}
-                            total={totalCount ?? 0}
-                            showSizeChanger
-                            onChange={(page, pageSize) =>
-                                setQuery((currentQuery) => ({
-                                    ...currentQuery,
-                                    current: page,
-                                    maxResultCount: pageSize,
-                                }))
-                            }
-                        />
-                    </div>
-                </>
-            ) : (
-                <Empty
-                    className={styles.emptyState}
-                    description="No onboarding plans match the current filter set."
-                />
-            )}
+            {listContent}
         </Space>
     );
 };

--- a/journeypoint/components/plans/style/style.ts
+++ b/journeypoint/components/plans/style/style.ts
@@ -173,4 +173,44 @@ export const useStyles = createStyles(({ css, token }) => ({
     alert: css`
         width: 100%;
     `,
+
+    importGrid: css`
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: 24px;
+        width: 100%;
+
+        @media (max-width: 992px) {
+            grid-template-columns: 1fr;
+        }
+    `,
+
+    importSourceCard: css`
+        width: 100%;
+    `,
+
+    importPreviewCard: css`
+        width: 100%;
+    `,
+
+    importTextArea: css`
+        min-height: 320px !important;
+    `,
+
+    warningsList: css`
+        margin: 0;
+        padding-left: 18px;
+    `,
+
+    previewModuleCard: css`
+        width: 100%;
+    `,
+
+    previewTableWrap: css`
+        width: 100%;
+
+        :global(.ant-table-wrapper) {
+            width: 100%;
+        }
+    `,
 }));

--- a/journeypoint/constants/auth/routes.ts
+++ b/journeypoint/constants/auth/routes.ts
@@ -8,6 +8,7 @@ export const APP_ROUTES = {
   tenants: "/dashboard/tenants",
   facilitatorDashboard: "/facilitator/dashboard",
   facilitatorPlans: "/facilitator/plans",
+  facilitatorMarkdownImport: "/facilitator/markdown-import",
   managerMyTasks: "/manager/my-tasks",
   enroleeMyJourney: "/enrolee/my-journey",
 };

--- a/journeypoint/providers/markdownImportProvider/actions.tsx
+++ b/journeypoint/providers/markdownImportProvider/actions.tsx
@@ -1,0 +1,115 @@
+import { createAction } from "redux-actions";
+import type { IMarkdownImportDraftState } from "@/types/markdown-import";
+import type { IMarkdownImportStateContext } from "./context";
+
+type MarkdownImportStatePayload = Partial<IMarkdownImportStateContext>;
+
+export enum MarkdownImportActionEnums {
+    setSource = "SET_MARKDOWN_IMPORT_SOURCE",
+    previewPending = "PREVIEW_MARKDOWN_IMPORT_PENDING",
+    previewSuccess = "PREVIEW_MARKDOWN_IMPORT_SUCCESS",
+    previewError = "PREVIEW_MARKDOWN_IMPORT_ERROR",
+    savePending = "SAVE_MARKDOWN_IMPORT_PENDING",
+    saveSuccess = "SAVE_MARKDOWN_IMPORT_SUCCESS",
+    saveError = "SAVE_MARKDOWN_IMPORT_ERROR",
+    setPreview = "SET_MARKDOWN_IMPORT_PREVIEW",
+    reset = "RESET_MARKDOWN_IMPORT",
+}
+
+export const setSource = createAction<
+    MarkdownImportStatePayload,
+    { sourceContent: string; sourceFileName?: string | null }
+>(
+    MarkdownImportActionEnums.setSource,
+    ({ sourceContent, sourceFileName }) => ({
+        sourceContent,
+        sourceFileName: sourceFileName ?? null,
+    }),
+);
+
+export const previewPending = createAction<MarkdownImportStatePayload>(
+    MarkdownImportActionEnums.previewPending,
+    () => ({
+        isPending: true,
+        isPreviewPending: true,
+        isSavePending: false,
+        isError: false,
+        isSuccess: false,
+    }),
+);
+
+export const previewSuccess = createAction<
+    MarkdownImportStatePayload,
+    IMarkdownImportDraftState
+>(
+    MarkdownImportActionEnums.previewSuccess,
+    (previewPlan) => ({
+        isPending: false,
+        isPreviewPending: false,
+        isError: false,
+        isSuccess: true,
+        previewPlan,
+    }),
+);
+
+export const previewError = createAction<MarkdownImportStatePayload>(
+    MarkdownImportActionEnums.previewError,
+    () => ({
+        isPending: false,
+        isPreviewPending: false,
+        isError: true,
+        isSuccess: false,
+    }),
+);
+
+export const savePending = createAction<MarkdownImportStatePayload>(
+    MarkdownImportActionEnums.savePending,
+    () => ({
+        isPending: true,
+        isSavePending: true,
+        isError: false,
+        isSuccess: false,
+    }),
+);
+
+export const saveSuccess = createAction<MarkdownImportStatePayload>(
+    MarkdownImportActionEnums.saveSuccess,
+    () => ({
+        isPending: false,
+        isSavePending: false,
+        isError: false,
+        isSuccess: true,
+    }),
+);
+
+export const saveError = createAction<MarkdownImportStatePayload>(
+    MarkdownImportActionEnums.saveError,
+    () => ({
+        isPending: false,
+        isSavePending: false,
+        isError: true,
+        isSuccess: false,
+    }),
+);
+
+export const setPreview = createAction<
+    MarkdownImportStatePayload,
+    IMarkdownImportDraftState | null
+>(
+    MarkdownImportActionEnums.setPreview,
+    (previewPlan) => ({ previewPlan }),
+);
+
+export const resetImport = createAction<MarkdownImportStatePayload>(
+    MarkdownImportActionEnums.reset,
+    () => ({
+        isPending: false,
+        isPreviewPending: false,
+        isSavePending: false,
+        isError: false,
+        isSuccess: false,
+        sourceContent: "",
+        sourceFileName: null,
+        previewPlan: null,
+    }),
+);

--- a/journeypoint/providers/markdownImportProvider/context.tsx
+++ b/journeypoint/providers/markdownImportProvider/context.tsx
@@ -1,0 +1,68 @@
+import { createContext } from "react";
+export type {
+    IMarkdownImportDraftState,
+    IMarkdownImportPreviewDto,
+    IMarkdownImportWarningDto,
+    IPreviewMarkdownImportRequest,
+    ISaveMarkdownImportRequest,
+} from "@/types/markdown-import";
+import type {
+    IMarkdownImportDraftState,
+    IMarkdownImportPreviewDto,
+} from "@/types/markdown-import";
+import type {
+    IOnboardingPlanDetailDto,
+    IOnboardingTaskEditorValues,
+} from "@/types/onboarding-plan";
+
+export interface IMarkdownImportStateContext {
+    isSuccess: boolean;
+    isPending: boolean;
+    isError: boolean;
+    isPreviewPending: boolean;
+    isSavePending: boolean;
+    sourceContent: string;
+    sourceFileName?: string | null;
+    previewPlan?: IMarkdownImportDraftState | null;
+}
+
+export interface IMarkdownImportActionContext {
+    setSourceContent: (content: string, fileName?: string | null) => void;
+    previewImport: () => Promise<IMarkdownImportPreviewDto | null>;
+    saveDraft: () => Promise<IOnboardingPlanDetailDto | null>;
+    resetImport: () => void;
+    setPreviewMetadata: (payload: {
+        name?: string;
+        description?: string;
+        targetAudience?: string;
+        durationDays?: number;
+    }) => void;
+    updatePreviewModule: (
+        moduleClientKey: string,
+        name: string,
+        description: string,
+    ) => void;
+    removePreviewModule: (moduleClientKey: string) => void;
+    updatePreviewTask: (
+        moduleClientKey: string,
+        taskClientKey: string,
+        payload: IOnboardingTaskEditorValues,
+    ) => void;
+    removePreviewTask: (moduleClientKey: string, taskClientKey: string) => void;
+}
+
+export const INITIAL_STATE: IMarkdownImportStateContext = {
+    isSuccess: false,
+    isPending: false,
+    isError: false,
+    isPreviewPending: false,
+    isSavePending: false,
+    sourceContent: "",
+    sourceFileName: null,
+    previewPlan: null,
+};
+
+export const MarkdownImportStateContext =
+    createContext<IMarkdownImportStateContext>(INITIAL_STATE);
+export const MarkdownImportActionContext =
+    createContext<IMarkdownImportActionContext | undefined>(undefined);

--- a/journeypoint/providers/markdownImportProvider/index.tsx
+++ b/journeypoint/providers/markdownImportProvider/index.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import React, { useContext, useReducer } from "react";
+import { getAxiosInstance } from "@/utils/axiosInstance";
+import {
+    IMarkdownImportDraftState,
+    IMarkdownImportPreviewDto,
+    IMarkdownImportPreviewModuleDto,
+    ISaveMarkdownImportRequest,
+} from "@/types/markdown-import";
+import {
+    IOnboardingModuleDraft,
+    IOnboardingPlanDetailDto,
+    IOnboardingPlanDraft,
+    IOnboardingTaskEditorValues,
+    OnboardingPlanStatus,
+} from "@/types/onboarding-plan";
+import {
+    previewError,
+    previewPending,
+    previewSuccess,
+    resetImport as resetImportAction,
+    saveError,
+    savePending,
+    saveSuccess,
+    setPreview,
+    setSource,
+} from "./actions";
+import {
+    INITIAL_STATE,
+    IMarkdownImportActionContext,
+    IMarkdownImportStateContext,
+    MarkdownImportActionContext,
+    MarkdownImportStateContext,
+} from "./context";
+import { MarkdownImportReducer } from "./reducer";
+
+const MARKDOWN_IMPORT_API_BASE = "/api/services/app/MarkdownImport";
+
+const createClientKey = (): string =>
+    typeof globalThis.crypto?.randomUUID === "function"
+        ? globalThis.crypto.randomUUID()
+        : `markdown-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const mapPreviewToDraftState = (
+    preview: IMarkdownImportPreviewDto,
+): IMarkdownImportDraftState => ({
+    plan: {
+        name: preview.name,
+        description: preview.description,
+        targetAudience: preview.targetAudience,
+        durationDays: preview.durationDays,
+        status: OnboardingPlanStatus.Draft,
+        modules: preview.modules.map(mapModuleToDraft),
+    },
+    warnings: preview.warnings,
+    canSave: preview.canSave,
+});
+
+const mapModuleToDraft = (
+    module: IMarkdownImportPreviewModuleDto,
+): IOnboardingModuleDraft => ({
+    clientKey: createClientKey(),
+    name: module.name,
+    description: module.description,
+    orderIndex: module.orderIndex,
+    tasks: module.tasks.map((task) => ({
+        clientKey: createClientKey(),
+        title: task.title,
+        description: task.description,
+        category: task.category,
+        orderIndex: task.orderIndex,
+        dueDayOffset: task.dueDayOffset,
+        assignmentTarget: task.assignmentTarget,
+        acknowledgementRule: task.acknowledgementRule,
+    })),
+});
+
+const mapDraftToSaveRequest = (
+    draftPlan: IOnboardingPlanDraft,
+): ISaveMarkdownImportRequest => ({
+    name: draftPlan.name.trim(),
+    description: draftPlan.description.trim(),
+    targetAudience: draftPlan.targetAudience.trim(),
+    durationDays: draftPlan.durationDays,
+    modules: draftPlan.modules.map((module) => ({
+        name: module.name.trim(),
+        description: module.description.trim(),
+        orderIndex: module.orderIndex,
+        tasks: module.tasks.map((task) => ({
+            title: task.title.trim(),
+            description: task.description.trim(),
+            category: task.category,
+            orderIndex: task.orderIndex,
+            dueDayOffset: task.dueDayOffset,
+            assignmentTarget: task.assignmentTarget,
+            acknowledgementRule: task.acknowledgementRule,
+        })),
+    })),
+});
+
+const updatePreviewDraft = (
+    previewState: IMarkdownImportDraftState | null | undefined,
+    updater: (draftPlan: IOnboardingPlanDraft) => IOnboardingPlanDraft,
+): IMarkdownImportDraftState | null => {
+    if (!previewState?.plan) {
+        return null;
+    }
+
+    const updatedPlan = updater(previewState.plan);
+    const canSave =
+        !!updatedPlan.name.trim() &&
+        !!updatedPlan.description.trim() &&
+        !!updatedPlan.targetAudience.trim() &&
+        updatedPlan.durationDays >= 1 &&
+        updatedPlan.modules.length > 0 &&
+        updatedPlan.modules.every((module) => !!module.name.trim()) &&
+        updatedPlan.modules.every((module) => !!module.description.trim()) &&
+        updatedPlan.modules.every((module) =>
+            module.tasks.every(
+                (task) => !!task.title.trim() && !!task.description.trim(),
+            ),
+        );
+
+    return {
+        ...previewState,
+        plan: updatedPlan,
+        canSave,
+    };
+};
+
+const applyPreviewMetadata = (
+    draftPlan: IOnboardingPlanDraft,
+    payload: {
+        name?: string;
+        description?: string;
+        targetAudience?: string;
+        durationDays?: number;
+    },
+): IOnboardingPlanDraft => ({
+    ...draftPlan,
+    ...payload,
+});
+
+const applyPreviewModuleChange = (
+    draftPlan: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    name: string,
+    description: string,
+): IOnboardingPlanDraft => ({
+    ...draftPlan,
+    modules: draftPlan.modules.map((module) =>
+        module.clientKey === moduleClientKey
+            ? { ...module, name, description }
+            : module,
+    ),
+});
+
+const removePreviewModuleFromDraft = (
+    draftPlan: IOnboardingPlanDraft,
+    moduleClientKey: string,
+): IOnboardingPlanDraft => ({
+    ...draftPlan,
+    modules: draftPlan.modules
+        .filter((module) => module.clientKey !== moduleClientKey)
+        .map((module, index) => ({
+            ...module,
+            orderIndex: index + 1,
+            tasks: module.tasks.map((task, taskIndex) => ({
+                ...task,
+                orderIndex: taskIndex + 1,
+            })),
+        })),
+});
+
+const updatePreviewTaskInDraft = (
+    draftPlan: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    taskClientKey: string,
+    payload: IOnboardingTaskEditorValues,
+): IOnboardingPlanDraft => ({
+    ...draftPlan,
+    modules: draftPlan.modules.map((module) =>
+        module.clientKey === moduleClientKey
+            ? {
+                ...module,
+                tasks: module.tasks.map((task) =>
+                    task.clientKey === taskClientKey
+                        ? { ...task, ...payload }
+                        : task,
+                ),
+            }
+            : module,
+    ),
+});
+
+const removePreviewTaskFromDraft = (
+    draftPlan: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    taskClientKey: string,
+): IOnboardingPlanDraft => ({
+    ...draftPlan,
+    modules: draftPlan.modules.map((module) =>
+        module.clientKey === moduleClientKey
+            ? {
+                ...module,
+                tasks: module.tasks
+                    .filter((task) => task.clientKey !== taskClientKey)
+                    .map((task, index) => ({
+                        ...task,
+                        orderIndex: index + 1,
+                    })),
+            }
+            : module,
+    ),
+});
+
+const getApiResult = <T,>(response: { data?: { result?: T } & T }): T =>
+    response.data?.result ?? (response.data as T);
+
+/**
+ * Provides markdown import preview, review, and save-as-draft state.
+ */
+export const MarkdownImportProvider: React.FC<{ children: React.ReactNode }> = ({
+    children,
+}) => {
+    const [state, dispatch] = useReducer(MarkdownImportReducer, INITIAL_STATE);
+
+    const setSourceContent = (content: string, fileName?: string | null): void => {
+        dispatch(setSource({ sourceContent: content, sourceFileName: fileName ?? null }));
+    };
+
+    const previewImport = async (): Promise<IMarkdownImportPreviewDto | null> => {
+        dispatch(previewPending());
+
+        try {
+            const response = await getAxiosInstance().post(
+                `${MARKDOWN_IMPORT_API_BASE}/Preview`,
+                {
+                    markdownContent: state.sourceContent,
+                    sourceFileName: state.sourceFileName,
+                },
+            );
+            const preview = getApiResult<IMarkdownImportPreviewDto>(response);
+            dispatch(previewSuccess(mapPreviewToDraftState(preview)));
+            return preview;
+        } catch (error) {
+            console.error(error);
+            dispatch(previewError());
+            return null;
+        }
+    };
+
+    const saveDraft = async (): Promise<IOnboardingPlanDetailDto | null> => {
+        if (!state.previewPlan?.plan) {
+            return null;
+        }
+
+        dispatch(savePending());
+
+        try {
+            const response = await getAxiosInstance().post(
+                `${MARKDOWN_IMPORT_API_BASE}/SaveDraft`,
+                mapDraftToSaveRequest(state.previewPlan.plan),
+            );
+            const detail = getApiResult<IOnboardingPlanDetailDto>(response);
+            dispatch(saveSuccess());
+            return detail;
+        } catch (error) {
+            console.error(error);
+            dispatch(saveError());
+            return null;
+        }
+    };
+
+    const resetImport = (): void => {
+        dispatch(resetImportAction());
+    };
+
+    const updatePreview = (
+        updater: (draftPlan: IOnboardingPlanDraft) => IOnboardingPlanDraft,
+    ): void => {
+        const updatedPreview = updatePreviewDraft(state.previewPlan, updater);
+
+        if (!updatedPreview) {
+            return;
+        }
+
+        dispatch(setPreview(updatedPreview));
+    };
+
+    const setPreviewMetadata: IMarkdownImportActionContext["setPreviewMetadata"] = (
+        payload,
+    ) => {
+        updatePreview((draftPlan) => applyPreviewMetadata(draftPlan, payload));
+    };
+
+    const updatePreviewModule: IMarkdownImportActionContext["updatePreviewModule"] = (
+        moduleClientKey,
+        name,
+        description,
+    ) => {
+        updatePreview((draftPlan) =>
+            applyPreviewModuleChange(draftPlan, moduleClientKey, name, description),
+        );
+    };
+
+    const removePreviewModule = (moduleClientKey: string): void => {
+        updatePreview((draftPlan) =>
+            removePreviewModuleFromDraft(draftPlan, moduleClientKey),
+        );
+    };
+
+    const updatePreviewTask = (
+        moduleClientKey: string,
+        taskClientKey: string,
+        payload: IOnboardingTaskEditorValues,
+    ): void => {
+        updatePreview((draftPlan) =>
+            updatePreviewTaskInDraft(
+                draftPlan,
+                moduleClientKey,
+                taskClientKey,
+                payload,
+            ),
+        );
+    };
+
+    const removePreviewTask = (
+        moduleClientKey: string,
+        taskClientKey: string,
+    ): void => {
+        updatePreview((draftPlan) =>
+            removePreviewTaskFromDraft(
+                draftPlan,
+                moduleClientKey,
+                taskClientKey,
+            ),
+        );
+    };
+
+    return (
+        <MarkdownImportStateContext.Provider value={state}>
+            <MarkdownImportActionContext.Provider
+                value={{
+                    setSourceContent,
+                    previewImport,
+                    saveDraft,
+                    resetImport,
+                    setPreviewMetadata,
+                    updatePreviewModule,
+                    removePreviewModule,
+                    updatePreviewTask,
+                    removePreviewTask,
+                }}
+            >
+                {children}
+            </MarkdownImportActionContext.Provider>
+        </MarkdownImportStateContext.Provider>
+    );
+};
+
+export const useMarkdownImportState = (): IMarkdownImportStateContext => {
+    const context = useContext(MarkdownImportStateContext);
+
+    if (context === undefined) {
+        throw new Error(
+            "useMarkdownImportState must be used within a MarkdownImportProvider",
+        );
+    }
+
+    return context;
+};
+
+export const useMarkdownImportActions = (): IMarkdownImportActionContext => {
+    const context = useContext(MarkdownImportActionContext);
+
+    if (context === undefined) {
+        throw new Error(
+            "useMarkdownImportActions must be used within a MarkdownImportProvider",
+        );
+    }
+
+    return context;
+};

--- a/journeypoint/providers/markdownImportProvider/reducer.tsx
+++ b/journeypoint/providers/markdownImportProvider/reducer.tsx
@@ -1,0 +1,48 @@
+import { handleActions } from "redux-actions";
+import { INITIAL_STATE, IMarkdownImportStateContext } from "./context";
+import { MarkdownImportActionEnums } from "./actions";
+
+export const MarkdownImportReducer = handleActions<
+    IMarkdownImportStateContext,
+    Partial<IMarkdownImportStateContext>
+>(
+    {
+        [MarkdownImportActionEnums.setSource]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.previewPending]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.previewSuccess]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.previewError]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.savePending]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.saveSuccess]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.saveError]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.setPreview]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [MarkdownImportActionEnums.reset]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+    },
+    INITIAL_STATE,
+);

--- a/journeypoint/providers/onboardingPlanProvider/index.tsx
+++ b/journeypoint/providers/onboardingPlanProvider/index.tsx
@@ -134,6 +134,156 @@ const withDraft = (
     return updater(draft);
 };
 
+const applyDraftMetadata = (
+    currentDraft: IOnboardingPlanDraft,
+    payload: Partial<IOnboardingPlanDraft>,
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    ...payload,
+});
+
+const appendDraftModule = (
+    currentDraft: IOnboardingPlanDraft,
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    modules: normalizeModules([
+        ...currentDraft.modules,
+        {
+            clientKey: createClientKey(),
+            name: "",
+            description: "",
+            orderIndex: currentDraft.modules.length + 1,
+            tasks: [],
+        },
+    ]),
+});
+
+const updateDraftModuleDetails = (
+    currentDraft: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    name: string,
+    description: string,
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    modules: currentDraft.modules.map((module) =>
+        module.clientKey === moduleClientKey
+            ? { ...module, name, description }
+            : module,
+    ),
+});
+
+const removeDraftModule = (
+    currentDraft: IOnboardingPlanDraft,
+    moduleClientKey: string,
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    modules: normalizeModules(
+        currentDraft.modules.filter((module) => module.clientKey !== moduleClientKey),
+    ),
+});
+
+const reorderDraftModule = (
+    currentDraft: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    direction: "up" | "down",
+): IOnboardingPlanDraft => {
+    const currentIndex = currentDraft.modules.findIndex(
+        (module) => module.clientKey === moduleClientKey,
+    );
+    const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+
+    return {
+        ...currentDraft,
+        modules: normalizeModules(moveItem(currentDraft.modules, currentIndex, targetIndex)),
+    };
+};
+
+const appendDraftTask = (
+    currentDraft: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    payload: IOnboardingTaskEditorValues,
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    modules: currentDraft.modules.map((module) =>
+        module.clientKey === moduleClientKey
+            ? {
+                ...module,
+                tasks: normalizeTasks([
+                    ...module.tasks,
+                    {
+                        clientKey: createClientKey(),
+                        orderIndex: module.tasks.length + 1,
+                        ...payload,
+                    },
+                ]),
+            }
+            : module,
+    ),
+});
+
+const updateDraftTaskDetails = (
+    currentDraft: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    taskClientKey: string,
+    payload: IOnboardingTaskEditorValues,
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    modules: currentDraft.modules.map((module) =>
+        module.clientKey === moduleClientKey
+            ? {
+                ...module,
+                tasks: module.tasks.map((task) =>
+                    task.clientKey === taskClientKey
+                        ? { ...task, ...payload }
+                        : task,
+                ),
+            }
+            : module,
+    ),
+});
+
+const removeDraftTask = (
+    currentDraft: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    taskClientKey: string,
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    modules: currentDraft.modules.map((module) =>
+        module.clientKey === moduleClientKey
+            ? {
+                ...module,
+                tasks: normalizeTasks(
+                    module.tasks.filter((task) => task.clientKey !== taskClientKey),
+                ),
+            }
+            : module,
+    ),
+});
+
+const reorderDraftTask = (
+    currentDraft: IOnboardingPlanDraft,
+    moduleClientKey: string,
+    taskClientKey: string,
+    direction: "up" | "down",
+): IOnboardingPlanDraft => ({
+    ...currentDraft,
+    modules: currentDraft.modules.map((module) => {
+        if (module.clientKey !== moduleClientKey) {
+            return module;
+        }
+
+        const currentIndex = module.tasks.findIndex(
+            (task) => task.clientKey === taskClientKey,
+        );
+        const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
+
+        return {
+            ...module,
+            tasks: normalizeTasks(moveItem(module.tasks, currentIndex, targetIndex)),
+        };
+    }),
+});
+
 const getApiResult = <T,>(response: { data?: { result?: T } & T }): T =>
     response.data?.result ?? (response.data as T);
 
@@ -255,26 +405,11 @@ export const OnboardingPlanProvider: React.FC<{ children: React.ReactNode }> = (
     };
 
     const setDraftMetadata: IOnboardingPlanActionContext["setDraftMetadata"] = (payload) => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            ...payload,
-        }));
+        updateDraft((currentDraft) => applyDraftMetadata(currentDraft, payload));
     };
 
     const addModule = (): void => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            modules: normalizeModules([
-                ...currentDraft.modules,
-                {
-                    clientKey: createClientKey(),
-                    name: "",
-                    description: "",
-                    orderIndex: currentDraft.modules.length + 1,
-                    tasks: [],
-                },
-            ]),
-        }));
+        updateDraft(appendDraftModule);
     };
 
     const updateModule = (
@@ -282,64 +417,31 @@ export const OnboardingPlanProvider: React.FC<{ children: React.ReactNode }> = (
         name: string,
         description: string,
     ): void => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            modules: currentDraft.modules.map((module) =>
-                module.clientKey === moduleClientKey
-                    ? { ...module, name, description }
-                    : module,
-            ),
-        }));
+        updateDraft((currentDraft) =>
+            updateDraftModuleDetails(currentDraft, moduleClientKey, name, description),
+        );
     };
 
     const removeModule = (moduleClientKey: string): void => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            modules: normalizeModules(
-                currentDraft.modules.filter((module) => module.clientKey !== moduleClientKey),
-            ),
-        }));
+        updateDraft((currentDraft) => removeDraftModule(currentDraft, moduleClientKey));
     };
 
     const moveModule = (
         moduleClientKey: string,
         direction: "up" | "down",
     ): void => {
-        updateDraft((currentDraft) => {
-            const currentIndex = currentDraft.modules.findIndex(
-                (module) => module.clientKey === moduleClientKey,
-            );
-            const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
-
-            return {
-                ...currentDraft,
-                modules: normalizeModules(moveItem(currentDraft.modules, currentIndex, targetIndex)),
-            };
-        });
+        updateDraft((currentDraft) =>
+            reorderDraftModule(currentDraft, moduleClientKey, direction),
+        );
     };
 
     const addTask = (
         moduleClientKey: string,
         payload: IOnboardingTaskEditorValues,
     ): void => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            modules: currentDraft.modules.map((module) =>
-                module.clientKey === moduleClientKey
-                    ? {
-                        ...module,
-                        tasks: normalizeTasks([
-                            ...module.tasks,
-                            {
-                                clientKey: createClientKey(),
-                                orderIndex: module.tasks.length + 1,
-                                ...payload,
-                            },
-                        ]),
-                    }
-                    : module,
-            ),
-        }));
+        updateDraft((currentDraft) =>
+            appendDraftTask(currentDraft, moduleClientKey, payload),
+        );
     };
 
     const updateTask = (
@@ -347,40 +449,23 @@ export const OnboardingPlanProvider: React.FC<{ children: React.ReactNode }> = (
         taskClientKey: string,
         payload: IOnboardingTaskEditorValues,
     ): void => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            modules: currentDraft.modules.map((module) =>
-                module.clientKey === moduleClientKey
-                    ? {
-                        ...module,
-                        tasks: module.tasks.map((task) =>
-                            task.clientKey === taskClientKey
-                                ? { ...task, ...payload }
-                                : task,
-                        ),
-                    }
-                    : module,
+        updateDraft((currentDraft) =>
+            updateDraftTaskDetails(
+                currentDraft,
+                moduleClientKey,
+                taskClientKey,
+                payload,
             ),
-        }));
+        );
     };
 
     const removeTask = (
         moduleClientKey: string,
         taskClientKey: string,
     ): void => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            modules: currentDraft.modules.map((module) =>
-                module.clientKey === moduleClientKey
-                    ? {
-                        ...module,
-                        tasks: normalizeTasks(
-                            module.tasks.filter((task) => task.clientKey !== taskClientKey),
-                        ),
-                    }
-                    : module,
-            ),
-        }));
+        updateDraft((currentDraft) =>
+            removeDraftTask(currentDraft, moduleClientKey, taskClientKey),
+        );
     };
 
     const moveTask = (
@@ -388,24 +473,14 @@ export const OnboardingPlanProvider: React.FC<{ children: React.ReactNode }> = (
         taskClientKey: string,
         direction: "up" | "down",
     ): void => {
-        updateDraft((currentDraft) => ({
-            ...currentDraft,
-            modules: currentDraft.modules.map((module) => {
-                if (module.clientKey !== moduleClientKey) {
-                    return module;
-                }
-
-                const currentIndex = module.tasks.findIndex(
-                    (task) => task.clientKey === taskClientKey,
-                );
-                const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
-
-                return {
-                    ...module,
-                    tasks: normalizeTasks(moveItem(module.tasks, currentIndex, targetIndex)),
-                };
-            }),
-        }));
+        updateDraft((currentDraft) =>
+            reorderDraftTask(
+                currentDraft,
+                moduleClientKey,
+                taskClientKey,
+                direction,
+            ),
+        );
     };
 
     return (

--- a/journeypoint/types/markdown-import/index.ts
+++ b/journeypoint/types/markdown-import/index.ts
@@ -1,0 +1,64 @@
+import type {
+    IOnboardingModuleDraft,
+    IOnboardingPlanDraft,
+    OnboardingTaskAcknowledgementRule,
+    OnboardingTaskAssignmentTarget,
+    OnboardingTaskCategory,
+} from "@/types/onboarding-plan";
+
+export interface IMarkdownImportWarningDto {
+    code: string;
+    message: string;
+    lineNumber?: number | null;
+    sectionName?: string | null;
+}
+
+export interface IMarkdownImportPreviewTaskDto {
+    title: string;
+    description: string;
+    category: OnboardingTaskCategory;
+    orderIndex: number;
+    dueDayOffset: number;
+    assignmentTarget: OnboardingTaskAssignmentTarget;
+    acknowledgementRule: OnboardingTaskAcknowledgementRule;
+}
+
+export interface IMarkdownImportPreviewModuleDto {
+    name: string;
+    description: string;
+    orderIndex: number;
+    tasks: IMarkdownImportPreviewTaskDto[];
+}
+
+export interface IMarkdownImportPreviewDto {
+    name: string;
+    description: string;
+    targetAudience: string;
+    durationDays: number;
+    modules: IMarkdownImportPreviewModuleDto[];
+    warnings: IMarkdownImportWarningDto[];
+    canSave: boolean;
+}
+
+export interface IPreviewMarkdownImportRequest {
+    markdownContent: string;
+    sourceFileName?: string | null;
+}
+
+export interface ISaveMarkdownImportRequest {
+    name: string;
+    description: string;
+    targetAudience: string;
+    durationDays: number;
+    modules: IMarkdownImportPreviewModuleDto[];
+}
+
+export interface IMarkdownImportDraftState {
+    plan: IOnboardingPlanDraft | null;
+    warnings: IMarkdownImportWarningDto[];
+    canSave: boolean;
+}
+
+export interface IMarkdownImportModuleTableRow extends IOnboardingModuleDraft {
+    warningCount?: number;
+}

--- a/specs/001-journeypoint-platform/tasks.md
+++ b/specs/001-journeypoint-platform/tasks.md
@@ -110,10 +110,10 @@ from markdown, and review document-extracted task proposals.
 - [x] T021 [US2] Register onboarding `DbSet` properties and mappings in `aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/JourneyPointDbContext.cs` and related configuration files
 - [x] T022 [US2] Add initial onboarding migration under `aspnet-core/src/JourneyPoint.EntityFrameworkCore/Migrations/`
 - [x] T023 [US2] Implement plan CRUD DTOs and application services in `aspnet-core/src/JourneyPoint.Application/Services/OnboardingPlanService/`
-- [ ] T024 [US2] Implement markdown import parsing and draft-save services in `aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/`
+- [x] T024 [US2] Implement markdown import parsing and draft-save services in `aspnet-core/src/JourneyPoint.Application/Services/MarkdownImportService/`
 - [ ] T025 [US2] Implement document upload, extraction orchestration, and proposal review services in `aspnet-core/src/JourneyPoint.Application/Services/OnboardingDocumentService/`
 - [x] T026 [P] [US2] Build facilitator plan list and editor pages in `journeypoint/app/(facilitator)/facilitator/plans/page.tsx` and `journeypoint/app/(facilitator)/facilitator/plans/[planId]/page.tsx`
-- [ ] T027 [P] [US2] Build markdown import UI in `journeypoint/app/(facilitator)/markdown-import/page.tsx` and `journeypoint/components/plans/MarkdownPreviewTable.tsx`
+- [x] T027 [P] [US2] Build markdown import UI in `journeypoint/app/(facilitator)/facilitator/markdown-import/page.tsx`, `journeypoint/components/plans/MarkdownImportWorkspace.tsx`, and `journeypoint/components/plans/MarkdownPreviewTable.tsx`
 - [x] T028 [P] [US2] Add plan provider state in `journeypoint/providers/onboardingPlanProvider/`
 - [x] T029 [US2] Add plan builder components in `journeypoint/components/plans/PlanCard.tsx`, `PlanEditor.tsx`, `ModulePanel.tsx`, `TaskFormModal.tsx`, and `TaskListEditor.tsx`
 


### PR DESCRIPTION
…save capabilities
Linking Issues: #23 

- Added MarkdownPreviewTable component for rendering parsed task rows and modules.
- Enhanced PlanCard component with cloning, publishing, and archiving actions.
- Updated PlanListView to include pagination and a button for importing markdown.
- Created markdown import provider with actions, context, and reducer for managing import state.
- Defined types for markdown import including preview and draft states.
- Refactored onboarding plan provider to support draft metadata and module/task management.
- Updated styles for new components and improved layout.
- Updated routes to include markdown import path.
- Modified tasks documentation to reflect completed features.