### PR TITLE
Add Groq journey personalisation feature

### DIFF
--- a/aspnet-core/src/JourneyPoint.Application/Services/AuditService/AiAuditLogService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/AuditService/AiAuditLogService.cs
@@ -24,7 +24,7 @@ namespace JourneyPoint.Application.Services.AuditService
         /// <summary>
         /// Persists one completed AI workflow audit record.
         /// </summary>
-        public async Task WriteAsync(AiAuditLogRequest request)
+        public async Task<Guid> WriteAsync(AiAuditLogRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
 
@@ -57,6 +57,7 @@ namespace JourneyPoint.Application.Services.AuditService
             };
 
             await _generationLogRepository.InsertAsync(log);
+            return log.Id;
         }
 
         private static DateTime NormalizeTimestamp(DateTime value)

--- a/aspnet-core/src/JourneyPoint.Application/Services/AuditService/IAiAuditLogService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/AuditService/IAiAuditLogService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace JourneyPoint.Application.Services.AuditService
@@ -10,6 +11,6 @@ namespace JourneyPoint.Application.Services.AuditService
         /// <summary>
         /// Persists one completed AI workflow audit record.
         /// </summary>
-        Task WriteAsync(AiAuditLogRequest request);
+        Task<Guid> WriteAsync(AiAuditLogRequest request);
     }
 }

--- a/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationContracts.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationContracts.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.GroqService
+{
+    /// <summary>
+    /// Represents one successful Groq journey personalisation result.
+    /// </summary>
+    public class GroqJourneyPersonalisationResult
+    {
+        /// <summary>
+        /// Gets or sets the audit record identifier for the AI run.
+        /// </summary>
+        public Guid GenerationLogId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Groq model name used for the run.
+        /// </summary>
+        public string ModelName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request timestamp.
+        /// </summary>
+        public DateTime RequestedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the safe proposal summary.
+        /// </summary>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the diff-ready proposed revisions.
+        /// </summary>
+        public IReadOnlyList<GroqJourneyTaskPersonalisationRevision> Revisions { get; set; }
+    }
+
+    /// <summary>
+    /// Represents one proposed revision for one existing journey task.
+    /// </summary>
+    public class GroqJourneyTaskPersonalisationRevision
+    {
+        /// <summary>
+        /// Gets or sets the target journey task id.
+        /// </summary>
+        public Guid JourneyTaskId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed title.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed task category.
+        /// </summary>
+        public OnboardingTaskCategory Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed assignment target.
+        /// </summary>
+        public OnboardingTaskAssignmentTarget AssignmentTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed acknowledgement rule.
+        /// </summary>
+        public OnboardingTaskAcknowledgementRule AcknowledgementRule { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed due-day offset.
+        /// </summary>
+        public int DueDayOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the model rationale for the revision.
+        /// </summary>
+        public string Rationale { get; set; }
+    }
+
+    internal sealed class GroqJourneyPersonalisationResponse
+    {
+        [JsonPropertyName("summary")]
+        public string Summary { get; set; }
+
+        [JsonPropertyName("revisions")]
+        public List<GroqJourneyPersonalisationRevisionResponse> Revisions { get; set; }
+    }
+
+    internal sealed class GroqJourneyPersonalisationRevisionResponse
+    {
+        [JsonPropertyName("journeyTaskId")]
+        public string JourneyTaskId { get; set; }
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("category")]
+        public string Category { get; set; }
+
+        [JsonPropertyName("assignmentTarget")]
+        public string AssignmentTarget { get; set; }
+
+        [JsonPropertyName("acknowledgementRule")]
+        public string AcknowledgementRule { get; set; }
+
+        [JsonPropertyName("dueDayOffset")]
+        public int DueDayOffset { get; set; }
+
+        [JsonPropertyName("rationale")]
+        public string Rationale { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationMapper.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationMapper.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.GroqService
+{
+    internal static class GroqJourneyPersonalisationMapper
+    {
+        internal static IReadOnlyList<GroqJourneyTaskPersonalisationRevision> MapRevisions(
+            GroqJourneyPersonalisationResponse payload,
+            IReadOnlyDictionary<Guid, JourneyTask> eligibleTasks)
+        {
+            var revisions = new List<GroqJourneyTaskPersonalisationRevision>();
+            var seenTaskIds = new HashSet<Guid>();
+
+            foreach (var revision in payload.Revisions ?? new List<GroqJourneyPersonalisationRevisionResponse>())
+            {
+                var journeyTaskId = ParseJourneyTaskId(revision.JourneyTaskId);
+                if (!eligibleTasks.TryGetValue(journeyTaskId, out var task))
+                {
+                    throw new InvalidOperationException("Groq returned a revision for an unknown or ineligible journey task.");
+                }
+
+                if (!seenTaskIds.Add(journeyTaskId))
+                {
+                    throw new InvalidOperationException("Groq returned duplicate revisions for the same journey task.");
+                }
+
+                var mappedRevision = new GroqJourneyTaskPersonalisationRevision
+                {
+                    JourneyTaskId = journeyTaskId,
+                    Title = NormalizeRequiredText(revision.Title, task.Title, JourneyTask.MaxTitleLength),
+                    Description = NormalizeRequiredText(
+                        revision.Description,
+                        task.Description,
+                        JourneyTask.MaxDescriptionLength),
+                    Category = ParseCategory(revision.Category, task.Category),
+                    AssignmentTarget = ParseAssignmentTarget(revision.AssignmentTarget, task.AssignmentTarget),
+                    AcknowledgementRule = ParseAcknowledgementRule(revision.AcknowledgementRule, task.AcknowledgementRule),
+                    DueDayOffset = EnsureDueDayOffset(revision.DueDayOffset),
+                    Rationale = NormalizeOptionalText(revision.Rationale, 1000)
+                };
+
+                if (IsNoOp(task, mappedRevision))
+                {
+                    continue;
+                }
+
+                revisions.Add(mappedRevision);
+            }
+
+            return revisions;
+        }
+
+        internal static string NormalizeSummary(string summary)
+        {
+            return NormalizeOptionalText(summary, 1000) ??
+                   "Journey personalisation proposal generated for facilitator review.";
+        }
+
+        private static Guid ParseJourneyTaskId(string value)
+        {
+            if (!Guid.TryParse(value, out var journeyTaskId) || journeyTaskId == Guid.Empty)
+            {
+                throw new InvalidOperationException("Groq returned an invalid journey task identifier.");
+            }
+
+            return journeyTaskId;
+        }
+
+        private static bool IsNoOp(JourneyTask task, GroqJourneyTaskPersonalisationRevision revision)
+        {
+            return task.Title == revision.Title &&
+                   task.Description == revision.Description &&
+                   task.Category == revision.Category &&
+                   task.AssignmentTarget == revision.AssignmentTarget &&
+                   task.AcknowledgementRule == revision.AcknowledgementRule &&
+                   task.DueDayOffset == revision.DueDayOffset;
+        }
+
+        private static string NormalizeRequiredText(string value, string fallback, int maxLength)
+        {
+            var normalizedValue = string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedValue))
+            {
+                throw new InvalidOperationException("Groq returned an empty required field.");
+            }
+
+            return normalizedValue.Length <= maxLength
+                ? normalizedValue
+                : normalizedValue[..maxLength];
+        }
+
+        private static string NormalizeOptionalText(string value, int maxLength)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            var normalizedValue = value.Trim();
+            return normalizedValue.Length <= maxLength
+                ? normalizedValue
+                : normalizedValue[..maxLength];
+        }
+
+        private static int EnsureDueDayOffset(int value)
+        {
+            if (value < JourneyTask.MinDueDayOffset)
+            {
+                throw new InvalidOperationException("Groq returned a negative due-day offset.");
+            }
+
+            return value;
+        }
+
+        private static OnboardingTaskCategory ParseCategory(string value, OnboardingTaskCategory fallback)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                ? fallback
+                : Enum.TryParse(value, true, out OnboardingTaskCategory parsedValue)
+                    ? parsedValue
+                    : throw new InvalidOperationException("Groq returned an unsupported onboarding task category.");
+        }
+
+        private static OnboardingTaskAssignmentTarget ParseAssignmentTarget(
+            string value,
+            OnboardingTaskAssignmentTarget fallback)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                ? fallback
+                : Enum.TryParse(value, true, out OnboardingTaskAssignmentTarget parsedValue)
+                    ? parsedValue
+                    : throw new InvalidOperationException("Groq returned an unsupported assignment target.");
+        }
+
+        private static OnboardingTaskAcknowledgementRule ParseAcknowledgementRule(
+            string value,
+            OnboardingTaskAcknowledgementRule fallback)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                ? fallback
+                : Enum.TryParse(value, true, out OnboardingTaskAcknowledgementRule parsedValue)
+                    ? parsedValue
+                    : throw new InvalidOperationException("Groq returned an unsupported acknowledgement rule.");
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationPromptFactory.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationPromptFactory.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.GroqService
+{
+    internal static class GroqJourneyPersonalisationPromptFactory
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+
+        internal static string BuildSystemPrompt()
+        {
+            return
+                "You personalise onboarding journey tasks into JSON only. " +
+                "Return one JSON object with keys summary and revisions. " +
+                "summary must be a short facilitator-facing explanation of the proposed improvements. " +
+                "revisions must be an array of objects keyed to existing journeyTaskId values only. " +
+                "Each revision must include journeyTaskId, title, description, category, assignmentTarget, acknowledgementRule, dueDayOffset, and rationale. " +
+                "You may revise only existing pending tasks. Do not add tasks, remove tasks, reorder tasks, change modules, or reference unknown task ids. " +
+                "Allowed category values: Orientation, Learning, Practice, Assessment, CheckIn. " +
+                "Allowed assignmentTarget values: Enrolee, Manager, Facilitator. " +
+                "Allowed acknowledgementRule values: NotRequired, Required. " +
+                "Keep dueDayOffset non-negative. " +
+                "If no useful revisions are needed, return an empty revisions array and explain that in summary. " +
+                "Do not wrap the JSON in markdown.";
+        }
+
+        internal static string BuildUserContent(
+            Hire hire,
+            Journey journey,
+            OnboardingPlan onboardingPlan,
+            IReadOnlyCollection<JourneyTask> eligibleTasks,
+            string facilitatorInstructions)
+        {
+            var payload = new
+            {
+                hire = new
+                {
+                    hireId = hire.Id,
+                    fullName = hire.FullName,
+                    roleTitle = hire.RoleTitle,
+                    department = hire.Department,
+                    startDate = hire.StartDate.ToString("yyyy-MM-dd")
+                },
+                journey = new
+                {
+                    journeyId = journey.Id,
+                    status = journey.Status.ToString(),
+                    planName = onboardingPlan.Name,
+                    targetAudience = onboardingPlan.TargetAudience,
+                    planDescription = Truncate(onboardingPlan.Description, 500),
+                    durationDays = onboardingPlan.DurationDays
+                },
+                facilitatorInstructions = string.IsNullOrWhiteSpace(facilitatorInstructions)
+                    ? null
+                    : Truncate(facilitatorInstructions, 1000),
+                tasks = eligibleTasks
+                    .OrderBy(task => task.ModuleOrderIndex)
+                    .ThenBy(task => task.TaskOrderIndex)
+                    .Select(task => new
+                    {
+                        journeyTaskId = task.Id,
+                        moduleTitle = task.ModuleTitle,
+                        moduleOrderIndex = task.ModuleOrderIndex,
+                        taskOrderIndex = task.TaskOrderIndex,
+                        title = task.Title,
+                        description = Truncate(task.Description, 1200),
+                        category = task.Category.ToString(),
+                        assignmentTarget = task.AssignmentTarget.ToString(),
+                        acknowledgementRule = task.AcknowledgementRule.ToString(),
+                        dueDayOffset = task.DueDayOffset,
+                        dueOn = task.DueOn.ToString("yyyy-MM-dd")
+                    })
+                    .ToList()
+            };
+
+            return JsonSerializer.Serialize(payload, SerializerOptions);
+        }
+
+        internal static string BuildAuditPromptSummary(
+            Hire hire,
+            Journey journey,
+            OnboardingPlan onboardingPlan,
+            int eligibleTaskCount,
+            string facilitatorInstructions)
+        {
+            var instructionsSummary = string.IsNullOrWhiteSpace(facilitatorInstructions)
+                ? "No facilitator instructions supplied."
+                : $"Facilitator instructions: {Truncate(facilitatorInstructions.Trim(), 300)}";
+
+            return
+                $"Request personalisation for hire '{hire.FullName}' on journey {journey.Id} " +
+                $"from plan '{onboardingPlan.Name}' across {eligibleTaskCount} pending tasks. " +
+                instructionsSummary;
+        }
+
+        private static string Truncate(string value, int maxLength)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            var trimmedValue = value.Trim();
+            return trimmedValue.Length <= maxLength
+                ? trimmedValue
+                : trimmedValue[..maxLength];
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationService.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Abp.Dependency;
+using JourneyPoint.Application.Services.AuditService;
+using JourneyPoint.Configuration;
+using JourneyPoint.Domains.Audit;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+using Microsoft.Extensions.Options;
+
+namespace JourneyPoint.Application.Services.GroqService
+{
+    /// <summary>
+    /// Generates backend-only Groq personalisation proposals for reviewable journey task revisions.
+    /// </summary>
+    public class GroqJourneyPersonalisationService : IGroqJourneyPersonalisationService, ITransientDependency
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private readonly GroqOptions _groqOptions;
+        private readonly IAiAuditLogService _aiAuditLogService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GroqJourneyPersonalisationService"/> class.
+        /// </summary>
+        public GroqJourneyPersonalisationService(
+            IOptions<GroqOptions> groqOptions,
+            IAiAuditLogService aiAuditLogService)
+        {
+            _groqOptions = groqOptions?.Value ?? throw new ArgumentNullException(nameof(groqOptions));
+            _aiAuditLogService = aiAuditLogService ?? throw new ArgumentNullException(nameof(aiAuditLogService));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether journey personalisation is configured and available.
+        /// </summary>
+        public bool IsEnabled =>
+            _groqOptions.Enabled &&
+            !string.IsNullOrWhiteSpace(_groqOptions.ApiKey) &&
+            _groqOptions.GetBaseUri() != null &&
+            !string.IsNullOrWhiteSpace(_groqOptions.Model);
+
+        /// <summary>
+        /// Requests diff-ready personalisation proposals for the provided journey tasks.
+        /// </summary>
+        public async Task<GroqJourneyPersonalisationResult> GenerateProposalAsync(
+            Hire hire,
+            Journey journey,
+            OnboardingPlan onboardingPlan,
+            IReadOnlyCollection<JourneyTask> eligibleTasks,
+            string facilitatorInstructions = null)
+        {
+            EnsureEnabled();
+            ArgumentNullException.ThrowIfNull(hire);
+            ArgumentNullException.ThrowIfNull(journey);
+            ArgumentNullException.ThrowIfNull(onboardingPlan);
+            ArgumentNullException.ThrowIfNull(eligibleTasks);
+
+            if (eligibleTasks.Count == 0)
+            {
+                throw new InvalidOperationException("Journey personalisation requires at least one eligible pending task.");
+            }
+
+            var modelName = _groqOptions.Model;
+            var systemPrompt = GroqJourneyPersonalisationPromptFactory.BuildSystemPrompt();
+            var userContent = GroqJourneyPersonalisationPromptFactory.BuildUserContent(
+                hire,
+                journey,
+                onboardingPlan,
+                eligibleTasks,
+                facilitatorInstructions);
+            var promptSummary = GroqJourneyPersonalisationPromptFactory.BuildAuditPromptSummary(
+                hire,
+                journey,
+                onboardingPlan,
+                eligibleTasks.Count,
+                facilitatorInstructions);
+            var startedAt = DateTime.UtcNow;
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                var responseText = await RequestJsonAsync(
+                    modelName,
+                    BuildMessages(systemPrompt, userContent));
+                var payload = DeserializeRequired<GroqJourneyPersonalisationResponse>(responseText);
+                var taskLookup = eligibleTasks.ToDictionary(task => task.Id);
+                var revisions = GroqJourneyPersonalisationMapper.MapRevisions(payload, taskLookup);
+                var generationLogId = await _aiAuditLogService.WriteAsync(new AiAuditLogRequest
+                {
+                    TenantId = journey.TenantId,
+                    WorkflowType = GenerationLogWorkflowType.Personalisation,
+                    Status = GenerationLogStatus.Succeeded,
+                    HireId = hire.Id,
+                    JourneyId = journey.Id,
+                    OnboardingPlanId = onboardingPlan.Id,
+                    ModelName = modelName,
+                    PromptSummary = promptSummary,
+                    ResponseSummary = responseText,
+                    TasksAdded = 0,
+                    TasksRevised = revisions.Count,
+                    StartedAt = startedAt,
+                    CompletedAt = startedAt.Add(stopwatch.Elapsed)
+                });
+
+                return new GroqJourneyPersonalisationResult
+                {
+                    GenerationLogId = generationLogId,
+                    ModelName = modelName,
+                    RequestedAt = startedAt,
+                    Summary = GroqJourneyPersonalisationMapper.NormalizeSummary(payload.Summary),
+                    Revisions = revisions
+                };
+            }
+            catch (Exception exception)
+            {
+                await _aiAuditLogService.WriteAsync(new AiAuditLogRequest
+                {
+                    TenantId = journey.TenantId,
+                    WorkflowType = GenerationLogWorkflowType.Personalisation,
+                    Status = GenerationLogStatus.Failed,
+                    HireId = hire.Id,
+                    JourneyId = journey.Id,
+                    OnboardingPlanId = onboardingPlan.Id,
+                    ModelName = modelName,
+                    PromptSummary = promptSummary,
+                    FailureReason = exception.Message,
+                    TasksAdded = 0,
+                    TasksRevised = 0,
+                    StartedAt = startedAt,
+                    CompletedAt = startedAt.Add(stopwatch.Elapsed)
+                });
+
+                throw;
+            }
+        }
+
+        private void EnsureEnabled()
+        {
+            if (!IsEnabled)
+            {
+                throw new InvalidOperationException("Groq journey personalisation is not configured.");
+            }
+        }
+
+        private async Task<string> RequestJsonAsync(string model, IEnumerable<object> messages)
+        {
+            using var httpClient = new HttpClient
+            {
+                BaseAddress = _groqOptions.GetBaseUri(),
+                Timeout = TimeSpan.FromSeconds(_groqOptions.TimeoutSeconds)
+            };
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", _groqOptions.ApiKey);
+
+            var requestPayload = new
+            {
+                model,
+                temperature = 0.3,
+                response_format = new
+                {
+                    type = "json_object"
+                },
+                messages
+            };
+
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, "chat/completions")
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(requestPayload, SerializerOptions),
+                    Encoding.UTF8,
+                    "application/json")
+            };
+
+            using var response = await httpClient.SendAsync(requestMessage);
+            var responseBody = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException(
+                    $"Groq personalisation failed with status {(int)response.StatusCode}: {responseBody}");
+            }
+
+            var completion = DeserializeRequired<GroqChatCompletionResponse>(responseBody);
+            var content = completion.Choices?.FirstOrDefault()?.Message?.Content;
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                throw new InvalidOperationException("Groq returned an empty personalisation response.");
+            }
+
+            return content;
+        }
+
+        private static IEnumerable<object> BuildMessages(string systemPrompt, string userContent)
+        {
+            return new object[]
+            {
+                new
+                {
+                    role = "system",
+                    content = systemPrompt
+                },
+                new
+                {
+                    role = "user",
+                    content = userContent
+                }
+            };
+        }
+
+        private static T DeserializeRequired<T>(string json)
+        {
+            var value = JsonSerializer.Deserialize<T>(json, SerializerOptions);
+            if (value == null)
+            {
+                throw new InvalidOperationException("Groq returned an unreadable JSON payload.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/GroqService/IGroqJourneyPersonalisationService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/GroqService/IGroqJourneyPersonalisationService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.GroqService
+{
+    /// <summary>
+    /// Defines backend-only Groq personalisation for journey task revisions.
+    /// </summary>
+    public interface IGroqJourneyPersonalisationService
+    {
+        /// <summary>
+        /// Gets a value indicating whether journey personalisation is configured and available.
+        /// </summary>
+        bool IsEnabled { get; }
+
+        /// <summary>
+        /// Requests diff-ready personalisation proposals for the provided journey tasks.
+        /// </summary>
+        Task<GroqJourneyPersonalisationResult> GenerateProposalAsync(
+            Hire hire,
+            Journey journey,
+            OnboardingPlan onboardingPlan,
+            IReadOnlyCollection<JourneyTask> eligibleTasks,
+            string facilitatorInstructions = null);
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/ApplyJourneyPersonalisationRequest.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/ApplyJourneyPersonalisationRequest.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace JourneyPoint.Application.Services.JourneyService.Dto
+{
+    /// <summary>
+    /// Applies selected personalisation revisions to one journey.
+    /// </summary>
+    public class ApplyJourneyPersonalisationRequest
+    {
+        /// <summary>
+        /// Gets or sets the audit log id for the reviewed AI run.
+        /// </summary>
+        public Guid GenerationLogId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the journey receiving the selected revisions.
+        /// </summary>
+        public Guid JourneyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected per-task revisions to apply.
+        /// </summary>
+        public IReadOnlyList<ApplyJourneyPersonalisationSelectionDto> Selections { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/ApplyJourneyPersonalisationSelectionDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/ApplyJourneyPersonalisationSelectionDto.cs
@@ -1,0 +1,51 @@
+using System;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.JourneyService.Dto
+{
+    /// <summary>
+    /// Carries one facilitator-approved task revision from a reviewed personalisation diff.
+    /// </summary>
+    public class ApplyJourneyPersonalisationSelectionDto
+    {
+        /// <summary>
+        /// Gets or sets the target journey task id.
+        /// </summary>
+        public Guid JourneyTaskId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reviewed task snapshot timestamp.
+        /// </summary>
+        public DateTime BaselineSnapshotAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the approved task title.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the approved task description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the approved task category.
+        /// </summary>
+        public OnboardingTaskCategory Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the approved assignment target.
+        /// </summary>
+        public OnboardingTaskAssignmentTarget AssignmentTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets the approved acknowledgement rule.
+        /// </summary>
+        public OnboardingTaskAcknowledgementRule AcknowledgementRule { get; set; }
+
+        /// <summary>
+        /// Gets or sets the approved due-day offset.
+        /// </summary>
+        public int DueDayOffset { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/JourneyPersonalisationProposalDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/JourneyPersonalisationProposalDto.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace JourneyPoint.Application.Services.JourneyService.Dto
+{
+    /// <summary>
+    /// Returns one facilitator-reviewable personalisation proposal for a journey.
+    /// </summary>
+    public class JourneyPersonalisationProposalDto
+    {
+        /// <summary>
+        /// Gets or sets the audit log id for the AI run.
+        /// </summary>
+        public Guid GenerationLogId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hire id.
+        /// </summary>
+        public Guid HireId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the journey id.
+        /// </summary>
+        public Guid JourneyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Groq model name.
+        /// </summary>
+        public string ModelName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request timestamp.
+        /// </summary>
+        public DateTime RequestedAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the facilitator-facing summary of the proposal.
+        /// </summary>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of revised tasks proposed by the AI response.
+        /// </summary>
+        public int RevisedTaskCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the diff-ready per-task revisions.
+        /// </summary>
+        public IReadOnlyList<JourneyTaskPersonalisationDiffDto> Diffs { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/JourneyTaskPersonalisationDiffDto.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/JourneyTaskPersonalisationDiffDto.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Application.Services.JourneyService.Dto
+{
+    /// <summary>
+    /// Returns one diff-ready AI revision for one existing journey task.
+    /// </summary>
+    public class JourneyTaskPersonalisationDiffDto
+    {
+        /// <summary>
+        /// Gets or sets the journey task id.
+        /// </summary>
+        public Guid JourneyTaskId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the copied module title.
+        /// </summary>
+        public string ModuleTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the copied task order index.
+        /// </summary>
+        public int TaskOrderIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the task snapshot timestamp used for stale-apply protection.
+        /// </summary>
+        public DateTime BaselineSnapshotAt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current task title.
+        /// </summary>
+        public string CurrentTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current task description.
+        /// </summary>
+        public string CurrentDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current task category.
+        /// </summary>
+        public OnboardingTaskCategory CurrentCategory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current task assignment target.
+        /// </summary>
+        public OnboardingTaskAssignmentTarget CurrentAssignmentTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current acknowledgement rule.
+        /// </summary>
+        public OnboardingTaskAcknowledgementRule CurrentAcknowledgementRule { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current due-day offset.
+        /// </summary>
+        public int CurrentDueDayOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current due date.
+        /// </summary>
+        public DateTime CurrentDueOn { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed task title.
+        /// </summary>
+        public string ProposedTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed task description.
+        /// </summary>
+        public string ProposedDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed task category.
+        /// </summary>
+        public OnboardingTaskCategory ProposedCategory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed task assignment target.
+        /// </summary>
+        public OnboardingTaskAssignmentTarget ProposedAssignmentTarget { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed acknowledgement rule.
+        /// </summary>
+        public OnboardingTaskAcknowledgementRule ProposedAcknowledgementRule { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed due-day offset.
+        /// </summary>
+        public int ProposedDueDayOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the proposed due date.
+        /// </summary>
+        public DateTime ProposedDueOn { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AI rationale for the revision.
+        /// </summary>
+        public string Rationale { get; set; }
+
+        /// <summary>
+        /// Gets or sets the field names that would change if the revision is applied.
+        /// </summary>
+        public IReadOnlyList<string> ChangedFields { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/RequestJourneyPersonalisationRequest.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/RequestJourneyPersonalisationRequest.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace JourneyPoint.Application.Services.JourneyService.Dto
+{
+    /// <summary>
+    /// Requests AI personalisation for one existing journey.
+    /// </summary>
+    public class RequestJourneyPersonalisationRequest
+    {
+        /// <summary>
+        /// Gets or sets the journey to personalise.
+        /// </summary>
+        public Guid JourneyId { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional facilitator instructions for the request.
+        /// </summary>
+        public string FacilitatorInstructions { get; set; }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/IJourneyAppService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/IJourneyAppService.cs
@@ -36,6 +36,16 @@ namespace JourneyPoint.Application.Services.JourneyService
         Task RemovePendingTaskAsync(Guid journeyTaskId);
 
         /// <summary>
+        /// Requests diff-ready AI personalisation revisions for one journey.
+        /// </summary>
+        Task<JourneyPersonalisationProposalDto> RequestPersonalisationAsync(RequestJourneyPersonalisationRequest input);
+
+        /// <summary>
+        /// Applies selected AI personalisation revisions to one journey.
+        /// </summary>
+        Task<JourneyDraftDto> ApplyPersonalisationAsync(ApplyJourneyPersonalisationRequest input);
+
+        /// <summary>
         /// Activates the generated journey for one hire after review is complete.
         /// </summary>
         Task<JourneyDraftDto> ActivateAsync(Guid hireId);

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/JourneyAppService.Personalisation.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/JourneyAppService.Personalisation.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Abp.Domain.Entities;
+using JourneyPoint.Application.Services.GroqService;
+using JourneyPoint.Application.Services.JourneyService.Dto;
+using JourneyPoint.Domains.Audit;
+using JourneyPoint.Domains.Hires;
+using Microsoft.EntityFrameworkCore;
+
+namespace JourneyPoint.Application.Services.JourneyService
+{
+    /// <summary>
+    /// Provides AI personalisation proposal and selective-apply workflows for journeys.
+    /// </summary>
+    public partial class JourneyAppService
+    {
+        /// <summary>
+        /// Requests diff-ready AI personalisation revisions for one journey.
+        /// </summary>
+        public async Task<JourneyPersonalisationProposalDto> RequestPersonalisationAsync(
+            RequestJourneyPersonalisationRequest input)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+
+            var tenantId = GetRequiredTenantId();
+            var journey = await GetJourneyForPersonalisationAsync(input.JourneyId, tenantId);
+            var eligibleTasks = GetEligibleTasksForPersonalisation(journey);
+
+            if (eligibleTasks.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "Journey personalisation requires at least one pending task.");
+            }
+
+            var proposal = await _groqJourneyPersonalisationService.GenerateProposalAsync(
+                journey.Hire,
+                journey,
+                journey.OnboardingPlan,
+                eligibleTasks,
+                input.FacilitatorInstructions);
+
+            return MapToProposalDto(journey, proposal);
+        }
+
+        /// <summary>
+        /// Applies selected AI personalisation revisions to one journey.
+        /// </summary>
+        public async Task<JourneyDraftDto> ApplyPersonalisationAsync(
+            ApplyJourneyPersonalisationRequest input)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+
+            var selections = NormalizeSelections(input.Selections);
+            var tenantId = GetRequiredTenantId();
+            var journey = await GetJourneyForPersonalisationAsync(input.JourneyId, tenantId);
+            await EnsureMatchingPersonalisationLogAsync(
+                input.GenerationLogId,
+                tenantId,
+                journey.HireId,
+                journey.Id);
+
+            foreach (var selection in selections)
+            {
+                var journeyTask = journey.Tasks.FirstOrDefault(task => task.Id == selection.JourneyTaskId);
+                if (journeyTask == null)
+                {
+                    throw new EntityNotFoundException(typeof(JourneyTask), selection.JourneyTaskId);
+                }
+
+                _hireJourneyManager.ApplyPersonalisedTaskRevision(
+                    journey.Hire,
+                    journey,
+                    journeyTask,
+                    selection.BaselineSnapshotAt,
+                    selection.Title,
+                    selection.Description,
+                    selection.Category,
+                    selection.AssignmentTarget,
+                    selection.AcknowledgementRule,
+                    selection.DueDayOffset);
+            }
+
+            await CurrentUnitOfWork.SaveChangesAsync();
+            return MapToDraftDto(journey.Hire, journey);
+        }
+
+        private async Task<Journey> GetJourneyForPersonalisationAsync(Guid journeyId, int tenantId)
+        {
+            var journey = await _journeyRepository.GetAll()
+                .Include(existingJourney => existingJourney.Hire)
+                .Include(existingJourney => existingJourney.OnboardingPlan)
+                .Include(existingJourney => existingJourney.Tasks)
+                .SingleOrDefaultAsync(existingJourney =>
+                    existingJourney.Id == journeyId &&
+                    existingJourney.TenantId == tenantId);
+
+            if (journey == null)
+            {
+                throw new EntityNotFoundException(typeof(Journey), journeyId);
+            }
+
+            if (journey.Status != JourneyStatus.Draft && journey.Status != JourneyStatus.Active)
+            {
+                throw new InvalidOperationException(
+                    "Only draft or active journeys can be personalised.");
+            }
+
+            return journey;
+        }
+
+        private async Task EnsureMatchingPersonalisationLogAsync(
+            Guid generationLogId,
+            int tenantId,
+            Guid hireId,
+            Guid journeyId)
+        {
+            var generationLog = await _generationLogRepository.FirstOrDefaultAsync(generationLogId);
+            if (generationLog == null)
+            {
+                throw new EntityNotFoundException(typeof(GenerationLog), generationLogId);
+            }
+
+            if (generationLog.TenantId != tenantId ||
+                generationLog.WorkflowType != GenerationLogWorkflowType.Personalisation ||
+                generationLog.Status != GenerationLogStatus.Succeeded ||
+                generationLog.HireId != hireId ||
+                generationLog.JourneyId != journeyId)
+            {
+                throw new InvalidOperationException(
+                    "The provided personalisation audit record does not match the selected journey.");
+            }
+        }
+
+        private static IReadOnlyList<JourneyTask> GetEligibleTasksForPersonalisation(Journey journey)
+        {
+            return journey.Tasks
+                .Where(task => task.Status == JourneyTaskStatus.Pending)
+                .OrderBy(task => task.ModuleOrderIndex)
+                .ThenBy(task => task.TaskOrderIndex)
+                .ToList();
+        }
+
+        private static IReadOnlyList<ApplyJourneyPersonalisationSelectionDto> NormalizeSelections(
+            IReadOnlyList<ApplyJourneyPersonalisationSelectionDto> selections)
+        {
+            if (selections == null || selections.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "At least one selected personalisation revision is required.");
+            }
+
+            var normalizedSelections = selections.ToList();
+            var duplicateTaskIds = normalizedSelections
+                .GroupBy(selection => selection.JourneyTaskId)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key)
+                .ToList();
+
+            if (duplicateTaskIds.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    "Duplicate journey task selections are not allowed.");
+            }
+
+            return normalizedSelections;
+        }
+
+        private static JourneyPersonalisationProposalDto MapToProposalDto(
+            Journey journey,
+            GroqJourneyPersonalisationResult proposal)
+        {
+            var diffs = proposal.Revisions
+                .Select(revision => MapToDiffDto(journey, revision))
+                .ToList();
+
+            return new JourneyPersonalisationProposalDto
+            {
+                GenerationLogId = proposal.GenerationLogId,
+                HireId = journey.HireId,
+                JourneyId = journey.Id,
+                ModelName = proposal.ModelName,
+                RequestedAt = proposal.RequestedAt,
+                Summary = proposal.Summary,
+                RevisedTaskCount = diffs.Count,
+                Diffs = diffs
+            };
+        }
+
+        private static JourneyTaskPersonalisationDiffDto MapToDiffDto(
+            Journey journey,
+            GroqJourneyTaskPersonalisationRevision revision)
+        {
+            var task = journey.Tasks.First(existingTask => existingTask.Id == revision.JourneyTaskId);
+            var proposedDueOn = journey.Hire.StartDate.Date.AddDays(revision.DueDayOffset);
+
+            return new JourneyTaskPersonalisationDiffDto
+            {
+                JourneyTaskId = task.Id,
+                ModuleTitle = task.ModuleTitle,
+                TaskOrderIndex = task.TaskOrderIndex,
+                BaselineSnapshotAt = GetSnapshotTimestamp(task),
+                CurrentTitle = task.Title,
+                CurrentDescription = task.Description,
+                CurrentCategory = task.Category,
+                CurrentAssignmentTarget = task.AssignmentTarget,
+                CurrentAcknowledgementRule = task.AcknowledgementRule,
+                CurrentDueDayOffset = task.DueDayOffset,
+                CurrentDueOn = task.DueOn,
+                ProposedTitle = revision.Title,
+                ProposedDescription = revision.Description,
+                ProposedCategory = revision.Category,
+                ProposedAssignmentTarget = revision.AssignmentTarget,
+                ProposedAcknowledgementRule = revision.AcknowledgementRule,
+                ProposedDueDayOffset = revision.DueDayOffset,
+                ProposedDueOn = proposedDueOn,
+                Rationale = revision.Rationale,
+                ChangedFields = GetChangedFields(task, revision)
+            };
+        }
+
+        private static IReadOnlyList<string> GetChangedFields(
+            JourneyTask task,
+            GroqJourneyTaskPersonalisationRevision revision)
+        {
+            var changedFields = new List<string>();
+
+            AddChangedField(changedFields, task.Title != revision.Title, "title");
+            AddChangedField(changedFields, task.Description != revision.Description, "description");
+            AddChangedField(changedFields, task.Category != revision.Category, "category");
+            AddChangedField(changedFields, task.AssignmentTarget != revision.AssignmentTarget, "assignmentTarget");
+            AddChangedField(changedFields, task.AcknowledgementRule != revision.AcknowledgementRule, "acknowledgementRule");
+            AddChangedField(changedFields, task.DueDayOffset != revision.DueDayOffset, "dueDayOffset");
+
+            return changedFields;
+        }
+
+        private static void AddChangedField(
+            ICollection<string> changedFields,
+            bool hasChanged,
+            string fieldName)
+        {
+            if (hasChanged)
+            {
+                changedFields.Add(fieldName);
+            }
+        }
+
+        private static DateTime GetSnapshotTimestamp(JourneyTask journeyTask)
+        {
+            var snapshotAt = journeyTask.LastModificationTime ?? journeyTask.CreationTime;
+            return snapshotAt.Kind switch
+            {
+                DateTimeKind.Utc => snapshotAt,
+                DateTimeKind.Local => snapshotAt.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(snapshotAt, DateTimeKind.Utc)
+            };
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/JourneyAppService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/JourneyService/JourneyAppService.cs
@@ -2,8 +2,10 @@ using System;
 using System.Threading.Tasks;
 using Abp.Authorization;
 using Abp.Domain.Repositories;
+using JourneyPoint.Application.Services.GroqService;
 using JourneyPoint.Application.Services.JourneyService.Dto;
 using JourneyPoint.Authorization;
+using JourneyPoint.Domains.Audit;
 using JourneyPoint.Domains.Hires;
 using JourneyPoint.Domains.OnboardingPlans;
 
@@ -19,7 +21,9 @@ namespace JourneyPoint.Application.Services.JourneyService
         private readonly IRepository<Journey, Guid> _journeyRepository;
         private readonly IRepository<JourneyTask, Guid> _journeyTaskRepository;
         private readonly IRepository<OnboardingPlan, Guid> _onboardingPlanRepository;
+        private readonly IRepository<GenerationLog, Guid> _generationLogRepository;
         private readonly HireJourneyManager _hireJourneyManager;
+        private readonly IGroqJourneyPersonalisationService _groqJourneyPersonalisationService;
 
         /// <summary>
         /// Initializes the journey generation application service dependencies.
@@ -29,13 +33,17 @@ namespace JourneyPoint.Application.Services.JourneyService
             IRepository<Journey, Guid> journeyRepository,
             IRepository<JourneyTask, Guid> journeyTaskRepository,
             IRepository<OnboardingPlan, Guid> onboardingPlanRepository,
-            HireJourneyManager hireJourneyManager)
+            IRepository<GenerationLog, Guid> generationLogRepository,
+            HireJourneyManager hireJourneyManager,
+            IGroqJourneyPersonalisationService groqJourneyPersonalisationService)
         {
             _hireRepository = hireRepository;
             _journeyRepository = journeyRepository;
             _journeyTaskRepository = journeyTaskRepository;
             _onboardingPlanRepository = onboardingPlanRepository;
+            _generationLogRepository = generationLogRepository;
             _hireJourneyManager = hireJourneyManager;
+            _groqJourneyPersonalisationService = groqJourneyPersonalisationService;
         }
 
         /// <summary>

--- a/aspnet-core/src/JourneyPoint.Core/Domains/Hires/HireJourneyManager.Personalisation.cs
+++ b/aspnet-core/src/JourneyPoint.Core/Domains/Hires/HireJourneyManager.Personalisation.cs
@@ -1,0 +1,87 @@
+using System;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Domains.Hires
+{
+    /// <summary>
+    /// Encapsulates selective-apply rules for AI-personalised journey task revisions.
+    /// </summary>
+    public partial class HireJourneyManager
+    {
+        /// <summary>
+        /// Applies one facilitator-approved AI revision to one pending journey task snapshot.
+        /// </summary>
+        public void ApplyPersonalisedTaskRevision(
+            Hire hire,
+            Journey journey,
+            JourneyTask journeyTask,
+            DateTime baselineSnapshotAt,
+            string title,
+            string description,
+            OnboardingTaskCategory category,
+            OnboardingTaskAssignmentTarget assignmentTarget,
+            OnboardingTaskAcknowledgementRule acknowledgementRule,
+            int dueDayOffset)
+        {
+            EnsurePersonalisationEligibleTaskForHire(hire, journey, journeyTask);
+            EnsureMatchingBaselineSnapshot(journeyTask, baselineSnapshotAt);
+
+            journeyTask.Title = NormalizeRequiredText(title, nameof(title), JourneyTask.MaxTitleLength);
+            journeyTask.Description = NormalizeRequiredText(
+                description,
+                nameof(description),
+                JourneyTask.MaxDescriptionLength);
+            journeyTask.Category = category;
+            journeyTask.AssignmentTarget = assignmentTarget;
+            journeyTask.AcknowledgementRule = acknowledgementRule;
+            journeyTask.DueDayOffset = EnsureDueDayOffset(dueDayOffset);
+            journeyTask.DueOn = CalculateDueOn(hire.StartDate, journeyTask.DueDayOffset);
+        }
+
+        private static void EnsurePersonalisationEligibleTaskForHire(Hire hire, Journey journey, JourneyTask journeyTask)
+        {
+            EnsureJourneyTaskForJourney(journey, journeyTask);
+            EnsureHire(hire);
+            EnsureMatchingTenant(hire.TenantId, journey.TenantId, nameof(journey));
+
+            if (journey.HireId != hire.Id)
+            {
+                throw new InvalidOperationException("Journey does not belong to the specified hire.");
+            }
+
+            if (journey.Status != JourneyStatus.Draft && journey.Status != JourneyStatus.Active)
+            {
+                throw new InvalidOperationException("Only draft or active journeys can accept personalisation changes.");
+            }
+
+            EnsurePendingTask(journeyTask);
+        }
+
+        private static void EnsureMatchingBaselineSnapshot(JourneyTask journeyTask, DateTime baselineSnapshotAt)
+        {
+            var currentSnapshotAt = GetSnapshotTimestamp(journeyTask);
+            var normalizedBaseline = NormalizeSnapshotTimestamp(baselineSnapshotAt);
+
+            if (currentSnapshotAt != normalizedBaseline)
+            {
+                throw new InvalidOperationException(
+                    "Journey task changed after the personalisation diff was generated. Request a fresh proposal before applying changes.");
+            }
+        }
+
+        private static DateTime GetSnapshotTimestamp(JourneyTask journeyTask)
+        {
+            return NormalizeSnapshotTimestamp(journeyTask.LastModificationTime ?? journeyTask.CreationTime);
+        }
+
+        private static DateTime NormalizeSnapshotTimestamp(DateTime value)
+        {
+            return value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Local => value.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            };
+        }
+    }
+}

--- a/specs/001-journeypoint-platform/contracts/rest-api.md
+++ b/specs/001-journeypoint-platform/contracts/rest-api.md
@@ -59,9 +59,8 @@ should remain ABP application-service friendly, typically under
 
 | Capability | Method | Purpose | Primary Actors |
 |-----------|--------|---------|----------------|
-| Request personalisation | POST | Trigger facilitator-approved journey personalisation | Facilitator |
-| Review personalisation diff | GET | Return before/after task comparison data | Facilitator |
-| Apply selected revisions | POST | Persist approved task revisions and audit metadata | Facilitator |
+| Request personalisation diff | POST | Trigger backend-only Groq personalisation for one same-tenant journey and return a diff-ready proposal payload plus generation-log metadata | Facilitator |
+| Apply selected revisions | POST | Persist only facilitator-approved task revisions after re-validating task eligibility and baseline snapshot timestamps | Facilitator |
 
 ## Participant Workspaces
 
@@ -105,6 +104,14 @@ should remain ABP application-service friendly, typically under
 - Draft review mutations must apply only to `JourneyTask` snapshot data and must
   reject writes that would mutate `OnboardingPlan`, `OnboardingModule`, or
   `OnboardingTask` records from the source template.
+- JP-020 personalisation preview is transient in the first slice and is
+  returned inline from the request call rather than being stored as a separate
+  proposal aggregate for later retrieval.
+- Personalisation requests may revise only existing `JourneyTask` snapshot
+  fields; task creation and task removal remain outside the AI contract.
+- Apply requests must include enough baseline task metadata to reject stale
+  proposals when a facilitator or participant has already changed the task
+  after the diff was generated.
 - Concrete API methods should continue to be exposed through
   interface-and-implementation AppService pairs with DTOs that live beside
   their service slice under `JourneyPoint.Application/Services/<Feature>/Dto/`.

--- a/specs/001-journeypoint-platform/data-model.md
+++ b/specs/001-journeypoint-platform/data-model.md
@@ -317,11 +317,105 @@ JourneyPoint has three primary domain areas:
 ### GenerationLog
 
 - Purpose: audit every AI personalisation or extraction workflow
-- Core fields: journey id, hire id, prompt summary, raw response summary, tasks
-  revised, tasks added, duration, status
+- Core fields:
+  - workflow type
+  - status
+  - hire id
+  - journey id
+  - onboarding plan id
+  - onboarding document id
+  - model name
+  - prompt summary
+  - response summary
+  - failure reason
+  - tasks revised
+  - tasks added
+  - started at
+  - completed at
+  - duration milliseconds
 - Relationships:
   - many-to-one with `Journey`
   - many-to-one with `Hire`
+  - many-to-one with `OnboardingPlan`
+  - many-to-one with `OnboardingDocument`
+
+### JourneyPersonalisationProposal (Transient Application Contract)
+
+- Purpose: represent one facilitator-reviewed AI personalisation preview before
+  any change is applied to the journey
+- Core fields:
+  - generation log id
+  - hire id
+  - journey id
+  - model name
+  - requested at
+  - summary
+  - revised task count
+  - task diffs
+- Validation:
+  - generated only for a same-tenant journey in `Draft` or `Active`
+  - includes only tasks that remain eligible for revision at request time
+  - is transient for JP-020 and is not persisted as a separate aggregate
+  - proposal payloads may revise existing task snapshots only and may not add
+    or remove tasks
+- Relationships:
+  - one-to-one with one `GenerationLog` for the originating AI run
+  - many-to-one with `Journey`
+  - many-to-one with `Hire`
+
+### JourneyTaskPersonalisationDiff (Transient Application Contract)
+
+- Purpose: carry one diff-ready proposed revision for one existing journey task
+- Core fields:
+  - journey task id
+  - baseline snapshot timestamp
+  - current snapshot fields
+  - proposed snapshot fields
+  - revision rationale
+  - changed field list
+- Validation:
+  - `JourneyTaskId` must resolve to an existing same-tenant task on the target
+    journey
+  - completed tasks are not eligible for personalisation diffs
+  - unsupported fields, duplicate task ids, and add/remove semantics are
+    rejected during parsing
+  - apply requests must fail if the current task no longer matches the reviewed
+    baseline timestamp
+
+### JP-020 Planned Application Files
+
+- `aspnet-core/src/JourneyPoint.Application/Services/GroqService/IGroqJourneyPersonalisationService.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationService.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationPromptFactory.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationContracts.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/GroqService/GroqJourneyPersonalisationMapper.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/JourneyAppService.Personalisation.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/RequestJourneyPersonalisationRequest.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/JourneyPersonalisationProposalDto.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/JourneyTaskPersonalisationDiffDto.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/ApplyJourneyPersonalisationRequest.cs`
+- `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/Dto/ApplyJourneyPersonalisationSelectionDto.cs`
+- `aspnet-core/src/JourneyPoint.Core/Domains/Hires/HireJourneyManager.Personalisation.cs`
+
+### JP-020 Validation Steps
+
+1. Request personalisation for a same-tenant journey in `Draft` or `Active`
+   and confirm the backend returns a diff-ready proposal without mutating any
+   `JourneyTask` records yet.
+2. Confirm the proposal payload includes only eligible pending tasks and that
+   each diff references an existing `JourneyTaskId` plus a baseline snapshot
+   timestamp from the reviewed task state.
+3. Simulate malformed or out-of-scope model output and confirm unsupported
+   fields, duplicate task ids, and add/remove semantics are rejected rather than
+   silently applied.
+4. Apply only a subset of the returned diffs and confirm the selected task
+   snapshots change while unselected tasks remain unchanged.
+5. Edit one task after requesting personalisation and then try to apply the old
+   diff; confirm the request is rejected as stale and requires a fresh
+   personalisation run.
+6. Confirm the personalisation request writes one `GenerationLog` row with
+   workflow type `Personalisation`, timing metadata, status, and proposed
+   revision counts.
 
 ## Engagement Intelligence and Intervention
 

--- a/specs/001-journeypoint-platform/plan.md
+++ b/specs/001-journeypoint-platform/plan.md
@@ -48,6 +48,31 @@ provider-backed state for hire queries and journey review mutations; and
 `antd-style` presentation components that keep helpers, constants, and typed
 contracts extracted into their dedicated frontend folders.
 
+The current planning increment for JP-020 focuses milestone 4 backend-only
+Groq journey personalisation and facilitator-controlled selective acceptance.
+This slice will assemble request context from a tenant-scoped journey plus its
+eligible pending task snapshots, parse the Groq response into diff-ready
+per-task revisions keyed to existing `JourneyTask` ids, and let facilitators
+apply only the selected revisions after re-validating task status and baseline
+snapshot timestamps. The minimal file surface spans
+`aspnet-core/src/JourneyPoint.Application/Services/GroqService/` for prompt,
+contract, parsing, and audit-writing concerns, plus
+`aspnet-core/src/JourneyPoint.Application/Services/JourneyService/` and
+`aspnet-core/src/JourneyPoint.Core/Domains/Hires/` for selective-apply
+orchestration and draft-safe task mutation rules.
+
+### JP-020 Primary Risks
+
+- Long journeys can produce oversized prompts or slow Groq responses, so the
+  request assembly must stay concise and include only the journey, hire, and
+  pending-task context needed for personalisation.
+- Model output can hallucinate unknown task ids or unsupported mutations, so
+  response parsing must use a strict JSON contract and whitelist only mutable
+  snapshot fields on existing tasks.
+- A facilitator can edit the journey between requesting and applying a diff, so
+  selective apply must fail fast when a task's baseline timestamp no longer
+  matches the proposal that was reviewed.
+
 ## Technical Context
 
 **Language/Version**: C# 12 on .NET 8; TypeScript 5 with React 19 and Next.js 16  

--- a/specs/001-journeypoint-platform/quickstart.md
+++ b/specs/001-journeypoint-platform/quickstart.md
@@ -110,8 +110,17 @@ Expected result:
 
 1. Sign in as an enrolee and complete a task.
 2. Sign in as a manager and complete a manager-assigned task.
-3. Trigger AI personalisation as a facilitator, review the diff, and accept a
-   subset of the proposed changes.
+3. Trigger AI personalisation as a facilitator for a same-tenant draft or
+   active journey and confirm the response returns a diff preview without
+   mutating any tasks yet.
+4. Review the returned per-task diff and apply only a subset of the proposed
+   changes.
+5. Confirm only the selected pending task snapshots change, while unselected
+   tasks and source onboarding templates remain unchanged.
+6. Re-run the flow after manually editing a task between request and apply, and
+   confirm the stale apply is rejected until a fresh diff is generated.
+7. Confirm the personalisation request writes an AI audit record with workflow
+   type `Personalisation`, status, timing, and revision summary metadata.
 
 ### Milestone 5 - Intelligence and Interventions
 

--- a/specs/001-journeypoint-platform/research.md
+++ b/specs/001-journeypoint-platform/research.md
@@ -265,3 +265,67 @@
 - Alternatives considered: Holding the editable journey draft entirely in client
   state until a later save was rejected because it would duplicate backend rules
   in the browser and increase mismatch risk for ordering and activation logic.
+
+## Decision 25: Assemble personalisation requests from current journey snapshots and only eligible pending tasks
+
+- Decision: JP-020 should build the Groq personalisation request from the
+  tenant-scoped hire, journey, onboarding-plan metadata, and only the current
+  pending `JourneyTask` snapshot fields that are eligible for revision.
+- Rationale: The model needs enough context to personalize wording and timing,
+  but sending only pending task snapshots keeps prompt size, latency, and token
+  cost bounded while avoiding accidental proposals against completed work.
+- Alternatives considered: Sending the full historical journey payload or
+  re-reading live template tasks was rejected because it would bloat the prompt
+  and weaken the snapshot-based journey model.
+
+## Decision 26: Return the personalisation diff preview inline instead of persisting a separate proposal aggregate
+
+- Decision: The request-personalisation endpoint should return a transient
+  diff-ready proposal payload immediately, and JP-020 should not introduce a new
+  persisted proposal entity before the facilitator applies selected changes.
+- Rationale: The system already has append-only `GenerationLog` audit records
+  for the AI run, while keeping the diff preview transient avoids another table,
+  another lifecycle, and another source of drift between review and apply.
+- Alternatives considered: Persisting a long-lived proposal aggregate was
+  rejected because it adds storage and cleanup complexity before there is a
+  proven workflow need for saved drafts of AI suggestions.
+
+## Decision 27: Parse Groq output into strict per-task field deltas only
+
+- Decision: The Groq response contract should be keyed to existing
+  `JourneyTaskId` values and limited to whitelisted editable snapshot fields
+  such as title, description, category, assignment target, acknowledgement
+  rule, and due-day offset.
+- Rationale: JP-020 is a selective-revision flow, not a second draft-generation
+  engine, so the parser must reject add/remove semantics, unknown task ids,
+  duplicate task proposals, and unsupported fields before anything reaches the
+  facilitator review step.
+- Alternatives considered: Allowing the model to add/remove tasks or return
+  free-form markdown diffs was rejected because it would be harder to validate,
+  harder to review safely, and contrary to the spec assumption that AI
+  personalisation revises existing tasks only.
+
+## Decision 28: Protect selective apply with baseline snapshot timestamps
+
+- Decision: Each task diff should include a baseline timestamp derived from the
+  current `JourneyTask` snapshot, and apply requests must fail when the current
+  task no longer matches that reviewed baseline.
+- Rationale: Facilitators can still edit draft or active journey tasks manually,
+  so this check prevents stale AI diffs from overwriting newer human-reviewed
+  content.
+- Alternatives considered: Blindly applying the selected changes or persisting
+  a heavyweight server-side proposal lock was rejected because one is unsafe and
+  the other adds unnecessary complexity for the first personalisation slice.
+
+## Decision 29: Reuse GenerationLog for personalisation runs and store proposal counts in audit metadata
+
+- Decision: Every JP-020 personalisation request should write one
+  `GenerationLog` row with `WorkflowType = Personalisation`, timing metadata,
+  model name, prompt/response summaries, and the count of revised tasks
+  proposed by the model.
+- Rationale: JP-019 already introduced the reusable audit trail, and JP-020
+  should consume that existing append-only model instead of inventing a second
+  audit store for personalisation.
+- Alternatives considered: Auditing only successful applies or adding a
+  personalisation-specific audit table was rejected because it would weaken
+  traceability and duplicate audit behavior across AI flows.

--- a/specs/001-journeypoint-platform/tasks.md
+++ b/specs/001-journeypoint-platform/tasks.md
@@ -170,8 +170,8 @@ review the task list, and activate the journey.
 review AI-generated journey revisions before applying them.
 
 - [x] T038 [P] [US4] Create AI audit entity in `aspnet-core/src/JourneyPoint.Core/Domains/Audit/GenerationLog.cs`
-- [ ] T039 [US4] Implement Groq extraction and personalisation client services in `aspnet-core/src/JourneyPoint.Application/Services/GroqService/`
-- [ ] T040 [US4] Extend journey application services for diff review and selective acceptance in `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/`
+- [x] T039 [US4] Implement Groq extraction and personalisation client services in `aspnet-core/src/JourneyPoint.Application/Services/GroqService/`
+- [x] T040 [US4] Extend journey application services for diff review and selective acceptance in `aspnet-core/src/JourneyPoint.Application/Services/JourneyService/`
 - [ ] T041 [P] [US4] Build enrolee journey pages in `journeypoint/app/(enrolee)/my-journey/page.tsx` and `journeypoint/app/(enrolee)/my-journey/tasks/[taskId]/page.tsx`
 - [ ] T042 [P] [US4] Build manager task page in `journeypoint/app/(manager)/my-tasks/page.tsx`
 - [ ] T043 [P] [US4] Add participant components in `journeypoint/components/journey/PersonalisationDiff.tsx` and `journeypoint/components/journey/JourneyTaskList.tsx`


### PR DESCRIPTION
Linking Issues: #32 

This pull request introduces a new Groq journey personalisation feature and refines the AI audit logging service. The main changes include adding models and mappers for Groq journey personalisation, implementing prompt factories for generating Groq requests, and updating the AI audit log service interface and implementation to return the log identifier.

**Groq Journey Personalisation Feature:**

* Added new models to represent Groq journey personalisation results, revisions, and internal response contracts in `GroqJourneyPersonalisationContracts.cs`. These models enable handling and storing AI-generated onboarding task proposals.
* Implemented `GroqJourneyPersonalisationMapper.cs` to map and validate Groq API responses into domain models, including normalization, validation, and conversion logic for journey task revisions.
* Added `GroqJourneyPersonalisationPromptFactory.cs` to generate system and user prompts for Groq, serialize onboarding plan and task data, and summarize audit prompts for logging and traceability.

**AI Audit Log Service Improvements:**

* Updated the `IAiAuditLogService` interface and its implementation in `AiAuditLogService` to return the generated log's `Guid` when writing an audit log, improving traceability of AI workflow audit records. [[1]](diffhunk://#diff-f635623b22c3ddca9c9e0f01772c36b42a760c1fc97f5f9eeff17102b4f926c5L13-R14) [[2]](diffhunk://#diff-effd4144f047530dd8402b2b3b82101683aa1f39a87ecefd66f6a3ca3bda4018L27-R27) [[3]](diffhunk://#diff-effd4144f047530dd8402b2b3b82101683aa1f39a87ecefd66f6a3ca3bda4018R60) [[4]](diffhunk://#diff-f635623b22c3ddca9c9e0f01772c36b42a760c1fc97f5f9eeff17102b4f926c5R1)