### PR TITLE
Implement engagement provider and enhance facilitator hire view

### DIFF
--- a/journeypoint/app/(facilitator)/facilitator/hires/[hireId]/page.tsx
+++ b/journeypoint/app/(facilitator)/facilitator/hires/[hireId]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/constants/auth/permissions";
 import HireDetailView from "@/components/hires/HireDetailView";
 import withAuth from "@/hoc/withAuth";
+import { EngagementProvider } from "@/providers/engagementProvider";
 import { HireProvider } from "@/providers/hireProvider";
 
 const FacilitatorHireDetailContent: React.FC = () => {
@@ -19,7 +20,9 @@ const FacilitatorHireDetailContent: React.FC = () => {
 
 const FacilitatorHireDetailPage: React.FC = () => (
     <HireProvider>
-        <FacilitatorHireDetailContent />
+        <EngagementProvider>
+            <FacilitatorHireDetailContent />
+        </EngagementProvider>
     </HireProvider>
 );
 

--- a/journeypoint/components/engagement/AtRiskFlagPanel.tsx
+++ b/journeypoint/components/engagement/AtRiskFlagPanel.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import React, { useState } from "react";
+import { Alert, Button, Card, Empty, Input, Select, Space, Tag, Typography, message } from "antd";
+import EngagementBadge from "@/components/engagement/EngagementBadge";
+import {
+    AT_RISK_FLAG_STATUS_COLORS,
+    AT_RISK_FLAG_STATUS_LABELS,
+    AT_RISK_RESOLUTION_LABELS,
+    FACILITATOR_RESOLUTION_OPTIONS,
+} from "@/constants/engagement/interventions";
+import { useStyles } from "@/components/engagement/style/style";
+import { AtRiskFlagStatus, AtRiskResolutionType } from "@/types/engagement";
+import type { IAtRiskFlagPanelProps } from "@/types/engagement/components";
+import { formatDisplayDateTime } from "@/utils/date";
+
+const { Paragraph, Text, Title } = Typography;
+
+/**
+ * Renders the active at-risk intervention panel with acknowledge and resolve actions.
+ */
+const AtRiskFlagPanel: React.FC<IAtRiskFlagPanelProps> = ({
+    activeFlag,
+    isPending,
+    onAcknowledge,
+    onResolve,
+}) => {
+    const { styles } = useStyles();
+    const [messageApi, messageContextHolder] = message.useMessage();
+    const [acknowledgementNotes, setAcknowledgementNotes] = useState("");
+    const [resolutionNotes, setResolutionNotes] = useState("");
+    const [resolutionType, setResolutionType] = useState<AtRiskResolutionType>(
+        AtRiskResolutionType.ManualFacilitatorResolution,
+    );
+
+    const handleAcknowledge = async (): Promise<void> => {
+        if (!activeFlag) {
+            return;
+        }
+
+        const result = await onAcknowledge({
+            flagId: activeFlag.id,
+            acknowledgementNotes,
+        });
+
+        if (!result) {
+            messageApi.error("The at-risk flag could not be acknowledged.");
+            return;
+        }
+
+        setAcknowledgementNotes("");
+        messageApi.success("At-risk flag acknowledged.");
+    };
+
+    const handleResolve = async (): Promise<void> => {
+        if (!activeFlag) {
+            return;
+        }
+
+        const result = await onResolve({
+            flagId: activeFlag.id,
+            resolutionType,
+            resolutionNotes,
+        });
+
+        if (!result) {
+            messageApi.error("The at-risk flag could not be resolved.");
+            return;
+        }
+
+        setResolutionNotes("");
+        setResolutionType(AtRiskResolutionType.ManualFacilitatorResolution);
+        messageApi.success("At-risk flag resolved.");
+    };
+
+    if (!activeFlag) {
+        return (
+            <Card title="Active At-Risk Panel" className={styles.panelCard}>
+                <Empty
+                    className={styles.emptyState}
+                    description="No active at-risk intervention is currently open for this hire."
+                />
+            </Card>
+        );
+    }
+
+    return (
+        <Card title="Active At-Risk Panel" className={styles.panelCard}>
+            {messageContextHolder}
+            <Space direction="vertical" size={16} className={styles.sectionStack}>
+                <Alert
+                    type="warning"
+                    message="This hire currently needs intervention."
+                    description={`Raised ${formatDisplayDateTime(activeFlag.raisedAt)}.`}
+                />
+
+                <div className={styles.detailList}>
+                    <div>
+                        <Text type="secondary">Flag status</Text>
+                        <div>
+                            <Tag color={AT_RISK_FLAG_STATUS_COLORS[activeFlag.status]}>
+                                {AT_RISK_FLAG_STATUS_LABELS[activeFlag.status]}
+                            </Tag>
+                        </div>
+                    </div>
+
+                    <div>
+                        <Text type="secondary">Raised classification</Text>
+                        <div>
+                            <EngagementBadge
+                                classification={activeFlag.classificationAtRaise}
+                                hasActiveAtRiskFlag
+                                compact
+                            />
+                        </div>
+                    </div>
+
+                    <div>
+                        <Text type="secondary">Raised at</Text>
+                        <Paragraph>{formatDisplayDateTime(activeFlag.raisedAt)}</Paragraph>
+                    </div>
+
+                    <div>
+                        <Text type="secondary">Acknowledged by</Text>
+                        <Paragraph>
+                            {activeFlag.acknowledgedByDisplayName || "Not acknowledged yet"}
+                        </Paragraph>
+                    </div>
+
+                    <div>
+                        <Text type="secondary">Acknowledged at</Text>
+                        <Paragraph>
+                            {formatDisplayDateTime(activeFlag.acknowledgedAt)}
+                        </Paragraph>
+                    </div>
+
+                    {activeFlag.acknowledgementNotes ? (
+                        <div>
+                            <Text type="secondary">Acknowledgement notes</Text>
+                            <Paragraph className={styles.noteText}>
+                                {activeFlag.acknowledgementNotes}
+                            </Paragraph>
+                        </div>
+                    ) : null}
+                </div>
+
+                {activeFlag.status === AtRiskFlagStatus.Active ? (
+                    <div className={styles.formStack}>
+                        <Title level={5}>Acknowledge intervention</Title>
+                        <Paragraph type="secondary">
+                            Record the first owner or note so this risk moves from an open
+                            alert into an acknowledged intervention.
+                        </Paragraph>
+                        <Input.TextArea
+                            rows={4}
+                            maxLength={2000}
+                            placeholder="Capture the first intervention note or owner hand-off."
+                            value={acknowledgementNotes}
+                            onChange={(event) => setAcknowledgementNotes(event.target.value)}
+                        />
+                        <div className={styles.actionRow}>
+                            <Button loading={isPending} onClick={() => void handleAcknowledge()}>
+                                Acknowledge Flag
+                            </Button>
+                        </div>
+                    </div>
+                ) : null}
+
+                <div className={styles.formStack}>
+                    <Title level={5}>Resolve intervention</Title>
+                    {activeFlag.status === AtRiskFlagStatus.Acknowledged ? (
+                        <Paragraph type="secondary">
+                            This flag is acknowledged and still open. Capture the final
+                            resolution to move it into history.
+                        </Paragraph>
+                    ) : (
+                        <Paragraph type="secondary">
+                            You can resolve immediately, but acknowledgement is recommended
+                            first so the intervention timeline stays complete.
+                        </Paragraph>
+                    )}
+                    <Select
+                        options={FACILITATOR_RESOLUTION_OPTIONS}
+                        value={resolutionType}
+                        onChange={(value) => setResolutionType(value as AtRiskResolutionType)}
+                    />
+                    <Input.TextArea
+                        rows={4}
+                        maxLength={2000}
+                        placeholder="Summarize the intervention outcome or exit reason."
+                        value={resolutionNotes}
+                        onChange={(event) => setResolutionNotes(event.target.value)}
+                    />
+                    <div className={styles.actionRow}>
+                        <Button type="primary" loading={isPending} onClick={() => void handleResolve()}>
+                            Resolve Flag
+                        </Button>
+                    </div>
+                    <Text type="secondary">
+                        Resolution type: {AT_RISK_RESOLUTION_LABELS[resolutionType]}
+                    </Text>
+                </div>
+            </Space>
+        </Card>
+    );
+};
+
+export default AtRiskFlagPanel;

--- a/journeypoint/components/engagement/EngagementBadge.tsx
+++ b/journeypoint/components/engagement/EngagementBadge.tsx
@@ -3,10 +3,11 @@
 import React from "react";
 import { Space, Tag } from "antd";
 import {
+    AT_RISK_BADGE_LABEL,
     ENGAGEMENT_CLASSIFICATION_COLORS,
     ENGAGEMENT_CLASSIFICATION_LABELS,
-} from "@/constants/pipeline/filters";
-import type { IEngagementBadgeProps } from "@/types/pipeline/components";
+} from "@/constants/engagement/badge";
+import type { IEngagementBadgeProps } from "@/types/engagement/components";
 import { formatPercentage } from "@/utils/pipeline/board";
 
 /**
@@ -16,13 +17,16 @@ const EngagementBadge: React.FC<IEngagementBadgeProps> = ({
     classification,
     compositeScore,
     hasActiveAtRiskFlag,
+    compact = false,
 }) => (
     <Space wrap size={[8, 8]}>
         <Tag color={ENGAGEMENT_CLASSIFICATION_COLORS[classification]}>
             {ENGAGEMENT_CLASSIFICATION_LABELS[classification]}
         </Tag>
-        <Tag>{formatPercentage(compositeScore)} score</Tag>
-        {hasActiveAtRiskFlag ? <Tag color="error">At-risk flag active</Tag> : null}
+        {compact || compositeScore === undefined ? null : (
+            <Tag>{formatPercentage(compositeScore)} score</Tag>
+        )}
+        {hasActiveAtRiskFlag ? <Tag color="error">{AT_RISK_BADGE_LABEL}</Tag> : null}
     </Space>
 );
 

--- a/journeypoint/components/engagement/InterventionHistoryPanel.tsx
+++ b/journeypoint/components/engagement/InterventionHistoryPanel.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React from "react";
+import { Card, Empty, Space, Tag, Typography } from "antd";
+import {
+    AT_RISK_FLAG_STATUS_COLORS,
+    AT_RISK_FLAG_STATUS_LABELS,
+    AT_RISK_RESOLUTION_LABELS,
+} from "@/constants/engagement/interventions";
+import { useStyles } from "@/components/engagement/style/style";
+import type { IInterventionHistoryPanelProps } from "@/types/engagement/components";
+import { formatDisplayDateTime } from "@/utils/date";
+
+const { Paragraph, Text, Title } = Typography;
+
+/**
+ * Renders resolved intervention history for one hire.
+ */
+const InterventionHistoryPanel: React.FC<IInterventionHistoryPanelProps> = ({
+    resolvedFlags,
+}) => {
+    const { styles } = useStyles();
+
+    return (
+        <Card title="Intervention History" className={styles.panelCard}>
+            {resolvedFlags.length > 0 ? (
+                <div className={styles.historyList}>
+                    {resolvedFlags.map((flag) => (
+                        <div key={flag.id} className={styles.historyItem}>
+                            <Space direction="vertical" size={12} className={styles.sectionStack}>
+                                <div>
+                                    <Title level={5}>
+                                        {flag.resolutionType
+                                            ? AT_RISK_RESOLUTION_LABELS[flag.resolutionType]
+                                            : "Resolved intervention"}
+                                    </Title>
+                                    <Tag color={AT_RISK_FLAG_STATUS_COLORS[flag.status]}>
+                                        {AT_RISK_FLAG_STATUS_LABELS[flag.status]}
+                                    </Tag>
+                                </div>
+
+                                <Text type="secondary">
+                                    Raised {formatDisplayDateTime(flag.raisedAt)} and resolved{" "}
+                                    {formatDisplayDateTime(flag.resolvedAt)}
+                                </Text>
+
+                                <Paragraph>
+                                    Resolved by {flag.resolvedByDisplayName || "System"} with{" "}
+                                    {flag.resolutionType
+                                        ? AT_RISK_RESOLUTION_LABELS[flag.resolutionType]
+                                        : "an unspecified resolution"}
+                                    .
+                                </Paragraph>
+
+                                {flag.acknowledgedByDisplayName ? (
+                                    <Paragraph>
+                                        Acknowledged by {flag.acknowledgedByDisplayName} on{" "}
+                                        {formatDisplayDateTime(flag.acknowledgedAt)}
+                                    </Paragraph>
+                                ) : null}
+
+                                {flag.acknowledgementNotes ? (
+                                    <div>
+                                        <Text type="secondary">Acknowledgement notes</Text>
+                                        <Paragraph className={styles.noteText}>
+                                            {flag.acknowledgementNotes}
+                                        </Paragraph>
+                                    </div>
+                                ) : null}
+
+                                {flag.resolutionNotes ? (
+                                    <div>
+                                        <Text type="secondary">Resolution notes</Text>
+                                        <Paragraph className={styles.noteText}>
+                                            {flag.resolutionNotes}
+                                        </Paragraph>
+                                    </div>
+                                ) : null}
+                            </Space>
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <Empty
+                    className={styles.emptyState}
+                    description="No resolved interventions have been recorded yet."
+                />
+            )}
+        </Card>
+    );
+};
+
+export default InterventionHistoryPanel;

--- a/journeypoint/components/engagement/style/style.ts
+++ b/journeypoint/components/engagement/style/style.ts
@@ -1,0 +1,96 @@
+import { createStyles } from "antd-style";
+
+export const useStyles = createStyles(({ css, token }) => ({
+    sectionStack: css`
+        width: 100%;
+    `,
+
+    statsGrid: css`
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 16px;
+        width: 100%;
+    `,
+
+    trendCard: css`
+        width: 100%;
+    `,
+
+    trendHeader: css`
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 16px;
+
+        @media (max-width: 768px) {
+            flex-direction: column;
+        }
+    `,
+
+    trendChartWrap: css`
+        width: 100%;
+        overflow-x: auto;
+    `,
+
+    trendSvg: css`
+        width: 100%;
+        min-width: 360px;
+        height: auto;
+    `,
+
+    trendLegend: css`
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        width: 100%;
+
+        @media (max-width: 768px) {
+            flex-direction: column;
+        }
+    `,
+
+    panelCard: css`
+        width: 100%;
+    `,
+
+    detailList: css`
+        display: grid;
+        gap: 12px;
+        width: 100%;
+    `,
+
+    formStack: css`
+        display: grid;
+        gap: 12px;
+        width: 100%;
+    `,
+
+    actionRow: css`
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    `,
+
+    noteText: css`
+        white-space: pre-wrap;
+        margin-bottom: 0 !important;
+    `,
+
+    historyItem: css`
+        border: 1px solid ${token.colorBorderSecondary};
+        border-radius: 12px;
+        padding: 16px;
+        background: ${token.colorBgContainer};
+    `,
+
+    historyList: css`
+        display: grid;
+        gap: 12px;
+        width: 100%;
+    `,
+
+    emptyState: css`
+        width: 100%;
+        padding: 24px 0;
+    `,
+}));

--- a/journeypoint/components/hires/HireDetailView.tsx
+++ b/journeypoint/components/hires/HireDetailView.tsx
@@ -13,6 +13,10 @@ import {
     Tag,
     Typography,
 } from "antd";
+import AtRiskFlagPanel from "@/components/engagement/AtRiskFlagPanel";
+import EngagementBadge from "@/components/engagement/EngagementBadge";
+import InterventionHistoryPanel from "@/components/engagement/InterventionHistoryPanel";
+import ScoreTrendChart from "@/components/journey/ScoreTrendChart";
 import { ArrowRightOutlined, ReloadOutlined } from "@ant-design/icons";
 import {
     HIRE_STATUS_LABELS,
@@ -26,7 +30,15 @@ import {
 } from "@/constants/journey/review";
 import { useStyles } from "@/components/hires/style/style";
 import { buildFacilitatorHireJourneyRoute } from "@/constants/auth/routes";
+import {
+    useEngagementActions,
+    useEngagementState,
+} from "@/providers/engagementProvider";
 import { useHireActions, useHireState } from "@/providers/hireProvider";
+import type {
+    IAcknowledgeAtRiskFlagRequest,
+    IResolveAtRiskFlagRequest,
+} from "@/types/engagement";
 import type { IHireDetailViewProps } from "@/types/hire/components";
 import { formatDisplayDate, formatDisplayDateTime } from "@/utils/date";
 import { useRouter } from "next/navigation";
@@ -40,14 +52,22 @@ const HireDetailView: React.FC<IHireDetailViewProps> = ({ hireId }) => {
     const { styles } = useStyles();
     const router = useRouter();
     const { getHireDetail, resetSelectedHire } = useHireActions();
+    const {
+        acknowledgeAtRiskFlag,
+        getHireIntelligence,
+        resetHireIntelligence,
+        resolveAtRiskFlag,
+    } = useEngagementActions();
     const { isDetailPending, selectedHire } = useHireState();
+    const { isMutationPending, isPending, selectedHireIntelligence } = useEngagementState();
 
     const loadHireEffect = useEffectEvent(async (): Promise<void> => {
-        await getHireDetail(hireId);
+        await Promise.all([getHireDetail(hireId), getHireIntelligence(hireId)]);
     });
 
     const clearSelectedHire = useEffectEvent((): void => {
         resetSelectedHire();
+        resetHireIntelligence();
     });
 
     useEffect(() => {
@@ -59,7 +79,7 @@ const HireDetailView: React.FC<IHireDetailViewProps> = ({ hireId }) => {
     }, [hireId]);
 
     const refreshHire = async (): Promise<void> => {
-        await getHireDetail(hireId);
+        await Promise.all([getHireDetail(hireId), getHireIntelligence(hireId)]);
     };
 
     const handleOpenJourney = (): void => {
@@ -68,13 +88,23 @@ const HireDetailView: React.FC<IHireDetailViewProps> = ({ hireId }) => {
         });
     };
 
-    if (isDetailPending && !selectedHire) {
+    const handleAcknowledgeFlag = async (
+        payload: IAcknowledgeAtRiskFlagRequest,
+    ): Promise<boolean> => Boolean(await acknowledgeAtRiskFlag(hireId, payload));
+
+    const handleResolveFlag = async (
+        payload: IResolveAtRiskFlagRequest,
+    ): Promise<boolean> => Boolean(await resolveAtRiskFlag(hireId, payload));
+
+    if ((isDetailPending || isPending) && !selectedHire) {
         return <Spin size="large" className={styles.loadingWrap} />;
     }
 
     if (!selectedHire) {
         return <Empty className={styles.emptyState} description="Hire record not found." />;
     }
+
+    const currentSnapshot = selectedHireIntelligence?.currentSnapshot;
 
     return (
         <Space orientation="vertical" size={24} className={styles.pageRoot}>
@@ -98,13 +128,21 @@ const HireDetailView: React.FC<IHireDetailViewProps> = ({ hireId }) => {
                         ) : (
                             <Tag>No journey generated</Tag>
                         )}
+                        {currentSnapshot ? (
+                            <EngagementBadge
+                                classification={currentSnapshot.classification}
+                                compositeScore={currentSnapshot.compositeScore}
+                                hasActiveAtRiskFlag={Boolean(selectedHireIntelligence?.activeFlag)}
+                                compact
+                            />
+                        ) : null}
                     </Space>
                 </div>
 
                 <Space wrap className={styles.pageActions}>
                     <Button
                         icon={<ReloadOutlined />}
-                        loading={isDetailPending}
+                        loading={isDetailPending || isPending}
                         onClick={() => void refreshHire()}
                     >
                         Refresh
@@ -193,7 +231,73 @@ const HireDetailView: React.FC<IHireDetailViewProps> = ({ hireId }) => {
                             </Descriptions.Item>
                         </Descriptions>
                     </Card>
+
+                    <Card title="Current Engagement">
+                        {currentSnapshot ? (
+                            <Space orientation="vertical" size={16} className={styles.pageRoot}>
+                                <EngagementBadge
+                                    classification={currentSnapshot.classification}
+                                    compositeScore={currentSnapshot.compositeScore}
+                                    hasActiveAtRiskFlag={Boolean(selectedHireIntelligence?.activeFlag)}
+                                />
+                                <div className={styles.summaryGrid}>
+                                    <Statistic
+                                        title="Composite score"
+                                        value={currentSnapshot.compositeScore}
+                                        precision={0}
+                                        suffix="%"
+                                    />
+                                    <Statistic
+                                        title="Completion rate"
+                                        value={currentSnapshot.completionRate}
+                                        precision={0}
+                                        suffix="%"
+                                    />
+                                    <Statistic
+                                        title="Days since activity"
+                                        value={currentSnapshot.daysSinceLastActivity}
+                                    />
+                                    <Statistic
+                                        title="Overdue tasks"
+                                        value={currentSnapshot.overdueTaskCount}
+                                    />
+                                    <Statistic
+                                        title="Snapshots"
+                                        value={selectedHireIntelligence?.snapshotHistory.length ?? 0}
+                                    />
+                                </div>
+                                <Paragraph type="secondary">
+                                    Current stage: {selectedHireIntelligence?.currentStageTitle || "Not available"}
+                                </Paragraph>
+                                <Paragraph type="secondary">
+                                    Resolved interventions: {selectedHireIntelligence?.resolvedFlags.length ?? 0}
+                                </Paragraph>
+                            </Space>
+                        ) : (
+                            <Paragraph type="secondary">
+                                Engagement snapshots will appear here after the intelligence
+                                service computes the first score for this hire.
+                            </Paragraph>
+                        )}
+                    </Card>
                 </Space>
+            </div>
+
+            <ScoreTrendChart
+                currentSnapshot={currentSnapshot}
+                snapshotHistory={selectedHireIntelligence?.snapshotHistory ?? []}
+            />
+
+            <div className={styles.detailGrid}>
+                <AtRiskFlagPanel
+                    activeFlag={selectedHireIntelligence?.activeFlag}
+                    isPending={isMutationPending}
+                    onAcknowledge={handleAcknowledgeFlag}
+                    onResolve={handleResolveFlag}
+                />
+                <InterventionHistoryPanel
+                    resolvedFlags={selectedHireIntelligence?.resolvedFlags ?? []}
+                />
             </div>
         </Space>
     );

--- a/journeypoint/components/journey/ScoreTrendChart.tsx
+++ b/journeypoint/components/journey/ScoreTrendChart.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import React from "react";
+import { Card, Empty, Space, Statistic, Typography } from "antd";
+import { useStyles } from "@/components/engagement/style/style";
+import type { IScoreTrendChartProps } from "@/types/engagement/components";
+import {
+    getTrendChartModel,
+    getTrendDeltaLabel,
+    TREND_GRID_LINES,
+} from "@/utils/engagement/chart";
+import { formatDisplayDateTime } from "@/utils/date";
+
+const { Paragraph, Text, Title } = Typography;
+
+/**
+ * Renders the hire-level engagement score trend from persisted snapshot history.
+ */
+const ScoreTrendChart: React.FC<IScoreTrendChartProps> = ({
+    currentSnapshot,
+    snapshotHistory,
+}) => {
+    const { styles } = useStyles();
+    const chartModel = getTrendChartModel(currentSnapshot, snapshotHistory);
+
+    if (!chartModel) {
+        return (
+            <Card title="Score Trend" className={styles.trendCard}>
+                <Empty
+                    className={styles.emptyState}
+                    description="No engagement snapshots have been recorded yet."
+                />
+            </Card>
+        );
+    }
+
+    return (
+        <Card title="Score Trend" className={styles.trendCard}>
+            <Space direction="vertical" size={16} className={styles.sectionStack}>
+                <div className={styles.trendHeader}>
+                    <div>
+                        <Title level={5}>Engagement over time</Title>
+                        <Paragraph type="secondary">
+                            {getTrendDeltaLabel(chartModel)}
+                        </Paragraph>
+                        {chartModel.hasRepeatedSameDaySnapshots ? (
+                            <Paragraph type="secondary">
+                                Multiple snapshots were recorded on the same day, so the chart
+                                is using date-and-time tick labels instead of repeating one date.
+                            </Paragraph>
+                        ) : null}
+                    </div>
+
+                    <Space size={24}>
+                        <Statistic
+                            title="Latest score"
+                            value={chartModel.latestScore}
+                            precision={0}
+                            suffix="%"
+                        />
+                        <Statistic
+                            title="Range"
+                            value={`${Math.round(chartModel.lowestScore)}-${Math.round(
+                                chartModel.highestScore,
+                            )}%`}
+                        />
+                    </Space>
+                </div>
+
+                <div className={styles.trendChartWrap}>
+                    <svg
+                        className={styles.trendSvg}
+                        viewBox={`0 0 ${chartModel.width} ${180}`}
+                        role="img"
+                        aria-label="Engagement score trend chart"
+                    >
+                        {TREND_GRID_LINES.map((gridLine) => (
+                            <g key={gridLine.key}>
+                                <line
+                                    x1={24}
+                                    y1={gridLine.y}
+                                    x2={chartModel.width - 24}
+                                    y2={gridLine.y}
+                                    stroke="#d9d9d9"
+                                    strokeDasharray="4 4"
+                                />
+                                <text
+                                    x={0}
+                                    y={gridLine.y + 4}
+                                    fontSize="12"
+                                    fill="#8c8c8c"
+                                >
+                                    {gridLine.label}
+                                </text>
+                            </g>
+                        ))}
+
+                        <polyline
+                            fill="none"
+                            stroke="#1677ff"
+                            strokeWidth="3"
+                            points={chartModel.polylinePoints}
+                        />
+
+                        {chartModel.points.map((point) => (
+                            <g key={point.key}>
+                                <circle cx={point.x} cy={point.y} r="5" fill="#1677ff" />
+                                <title>{point.tooltip}</title>
+                            </g>
+                        ))}
+
+                        {chartModel.ticks.map((tick) => (
+                            <g key={tick.key}>
+                                <text
+                                    x={tick.x}
+                                    y={174}
+                                    textAnchor="middle"
+                                    fontSize="11"
+                                    fill="#8c8c8c"
+                                >
+                                    {tick.label}
+                                </text>
+                            </g>
+                        ))}
+                    </svg>
+                </div>
+
+                <div className={styles.trendLegend}>
+                    <Text type="secondary">
+                        Latest snapshot: {formatDisplayDateTime(currentSnapshot?.computedAt)}
+                    </Text>
+                    <Text type="secondary">
+                        Snapshot count: {chartModel.points.length}
+                    </Text>
+                </div>
+
+                <div className={styles.trendLegend}>
+                    <Text type="secondary">
+                        Hover points to inspect exact snapshot timestamps and scores.
+                    </Text>
+                    <Text type="secondary">
+                        Flat runs indicate unchanged scores across repeated computations.
+                    </Text>
+                </div>
+            </Space>
+        </Card>
+    );
+};
+
+export default ScoreTrendChart;

--- a/journeypoint/components/pipeline/PipelineBoardView.tsx
+++ b/journeypoint/components/pipeline/PipelineBoardView.tsx
@@ -24,7 +24,7 @@ import {
     PIPELINE_CLASSIFICATION_OPTIONS,
 } from "@/constants/pipeline/filters";
 import { usePipelineActions, usePipelineState } from "@/providers/pipelineProvider";
-import type { EngagementClassification } from "@/types/pipeline";
+import type { EngagementClassification } from "@/types/engagement";
 import type { IPipelineBoardViewProps } from "@/types/pipeline/components";
 import { formatDisplayDateTime } from "@/utils/date";
 import { getPipelineSummaryMetrics } from "@/utils/pipeline/board";

--- a/journeypoint/constants/engagement/badge.ts
+++ b/journeypoint/constants/engagement/badge.ts
@@ -6,4 +6,10 @@ export const ENGAGEMENT_CLASSIFICATION_LABELS: Record<EngagementClassification, 
     [EngagementClassification.AtRisk]: "At Risk",
 };
 
+export const ENGAGEMENT_CLASSIFICATION_COLORS: Record<EngagementClassification, string> = {
+    [EngagementClassification.Healthy]: "success",
+    [EngagementClassification.NeedsAttention]: "warning",
+    [EngagementClassification.AtRisk]: "error",
+};
+
 export const AT_RISK_BADGE_LABEL = "At-Risk Flag";

--- a/journeypoint/constants/engagement/interventions.ts
+++ b/journeypoint/constants/engagement/interventions.ts
@@ -1,0 +1,31 @@
+import type { SelectProps } from "antd";
+import { AtRiskFlagStatus, AtRiskResolutionType } from "@/types/engagement";
+
+export const AT_RISK_FLAG_STATUS_LABELS: Record<AtRiskFlagStatus, string> = {
+    [AtRiskFlagStatus.Active]: "Active",
+    [AtRiskFlagStatus.Acknowledged]: "Acknowledged",
+    [AtRiskFlagStatus.Resolved]: "Resolved",
+};
+
+export const AT_RISK_FLAG_STATUS_COLORS: Record<AtRiskFlagStatus, string> = {
+    [AtRiskFlagStatus.Active]: "error",
+    [AtRiskFlagStatus.Acknowledged]: "processing",
+    [AtRiskFlagStatus.Resolved]: "success",
+};
+
+export const AT_RISK_RESOLUTION_LABELS: Record<AtRiskResolutionType, string> = {
+    [AtRiskResolutionType.ManualFacilitatorResolution]: "Manual facilitator resolution",
+    [AtRiskResolutionType.AutomaticHealthyRecovery]: "Automatic healthy recovery",
+    [AtRiskResolutionType.HireExited]: "Hire exited",
+};
+
+export const FACILITATOR_RESOLUTION_OPTIONS: SelectProps["options"] = [
+    {
+        label: AT_RISK_RESOLUTION_LABELS[AtRiskResolutionType.ManualFacilitatorResolution],
+        value: AtRiskResolutionType.ManualFacilitatorResolution,
+    },
+    {
+        label: AT_RISK_RESOLUTION_LABELS[AtRiskResolutionType.HireExited],
+        value: AtRiskResolutionType.HireExited,
+    },
+];

--- a/journeypoint/constants/pipeline/filters.ts
+++ b/journeypoint/constants/pipeline/filters.ts
@@ -1,5 +1,9 @@
 import type { SelectProps } from "antd";
-import { EngagementClassification, type IPipelineBoardQueryState } from "@/types/pipeline";
+import {
+    ENGAGEMENT_CLASSIFICATION_LABELS,
+} from "@/constants/engagement/badge";
+import { EngagementClassification } from "@/types/engagement";
+import type { IPipelineBoardQueryState } from "@/types/pipeline";
 
 export const DEFAULT_PIPELINE_QUERY_STATE: IPipelineBoardQueryState = {
     keyword: "",
@@ -7,18 +11,6 @@ export const DEFAULT_PIPELINE_QUERY_STATE: IPipelineBoardQueryState = {
 };
 
 export const DEFAULT_PIPELINE_MAX_RESULT_COUNT = 200;
-
-export const ENGAGEMENT_CLASSIFICATION_LABELS: Record<EngagementClassification, string> = {
-    [EngagementClassification.Healthy]: "Healthy",
-    [EngagementClassification.NeedsAttention]: "Needs Attention",
-    [EngagementClassification.AtRisk]: "At Risk",
-};
-
-export const ENGAGEMENT_CLASSIFICATION_COLORS: Record<EngagementClassification, string> = {
-    [EngagementClassification.Healthy]: "success",
-    [EngagementClassification.NeedsAttention]: "warning",
-    [EngagementClassification.AtRisk]: "error",
-};
 
 export const PIPELINE_CLASSIFICATION_OPTIONS: SelectProps["options"] = [
     {

--- a/journeypoint/providers/engagementProvider/actions.tsx
+++ b/journeypoint/providers/engagementProvider/actions.tsx
@@ -1,0 +1,84 @@
+import { createAction } from "redux-actions";
+import type { IEngagementStateContext, IHireIntelligenceDetailDto } from "./context";
+
+type EngagementStatePayload = Partial<IEngagementStateContext>;
+
+export enum EngagementActionEnums {
+    getHireIntelligencePending = "GET_HIRE_INTELLIGENCE_PENDING",
+    getHireIntelligenceSuccess = "GET_HIRE_INTELLIGENCE_SUCCESS",
+    getHireIntelligenceError = "GET_HIRE_INTELLIGENCE_ERROR",
+    mutationPending = "ENGAGEMENT_MUTATION_PENDING",
+    mutationSuccess = "ENGAGEMENT_MUTATION_SUCCESS",
+    mutationError = "ENGAGEMENT_MUTATION_ERROR",
+    resetHireIntelligence = "RESET_HIRE_INTELLIGENCE",
+}
+
+export const getHireIntelligencePending = createAction<EngagementStatePayload>(
+    EngagementActionEnums.getHireIntelligencePending,
+    () => ({
+        isPending: true,
+        isError: false,
+        isSuccess: false,
+    }),
+);
+
+export const getHireIntelligenceSuccess = createAction<
+    EngagementStatePayload,
+    IHireIntelligenceDetailDto
+>(EngagementActionEnums.getHireIntelligenceSuccess, (selectedHireIntelligence) => ({
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+    selectedHireIntelligence,
+}));
+
+export const getHireIntelligenceError = createAction<EngagementStatePayload>(
+    EngagementActionEnums.getHireIntelligenceError,
+    () => ({
+        isPending: false,
+        isError: true,
+        isSuccess: false,
+    }),
+);
+
+export const mutationPending = createAction<EngagementStatePayload>(
+    EngagementActionEnums.mutationPending,
+    () => ({
+        isPending: true,
+        isMutationPending: true,
+        isError: false,
+        isSuccess: false,
+    }),
+);
+
+export const mutationSuccess = createAction<
+    EngagementStatePayload,
+    IHireIntelligenceDetailDto
+>(EngagementActionEnums.mutationSuccess, (selectedHireIntelligence) => ({
+    isPending: false,
+    isMutationPending: false,
+    isError: false,
+    isSuccess: true,
+    selectedHireIntelligence,
+}));
+
+export const mutationError = createAction<EngagementStatePayload>(
+    EngagementActionEnums.mutationError,
+    () => ({
+        isPending: false,
+        isMutationPending: false,
+        isError: true,
+        isSuccess: false,
+    }),
+);
+
+export const resetHireIntelligence = createAction<EngagementStatePayload>(
+    EngagementActionEnums.resetHireIntelligence,
+    () => ({
+        isPending: false,
+        isMutationPending: false,
+        isError: false,
+        isSuccess: false,
+        selectedHireIntelligence: null,
+    }),
+);

--- a/journeypoint/providers/engagementProvider/context.tsx
+++ b/journeypoint/providers/engagementProvider/context.tsx
@@ -1,0 +1,43 @@
+import { createContext } from "react";
+export type {
+    IAcknowledgeAtRiskFlagRequest,
+    IHireIntelligenceDetailDto,
+    IResolveAtRiskFlagRequest,
+} from "@/types/engagement";
+import type {
+    IAcknowledgeAtRiskFlagRequest,
+    IHireIntelligenceDetailDto,
+    IResolveAtRiskFlagRequest,
+} from "@/types/engagement";
+
+export interface IEngagementStateContext {
+    isSuccess: boolean;
+    isPending: boolean;
+    isError: boolean;
+    isMutationPending: boolean;
+    selectedHireIntelligence?: IHireIntelligenceDetailDto | null;
+}
+
+export interface IEngagementActionContext {
+    getHireIntelligence: (hireId: string) => Promise<IHireIntelligenceDetailDto | null>;
+    acknowledgeAtRiskFlag: (
+        hireId: string,
+        payload: IAcknowledgeAtRiskFlagRequest,
+    ) => Promise<IHireIntelligenceDetailDto | null>;
+    resolveAtRiskFlag: (
+        hireId: string,
+        payload: IResolveAtRiskFlagRequest,
+    ) => Promise<IHireIntelligenceDetailDto | null>;
+    resetHireIntelligence: () => void;
+}
+
+export const INITIAL_STATE: IEngagementStateContext = {
+    isSuccess: false,
+    isPending: false,
+    isError: false,
+    isMutationPending: false,
+    selectedHireIntelligence: null,
+};
+
+export const EngagementStateContext = createContext<IEngagementStateContext>(INITIAL_STATE);
+export const EngagementActionContext = createContext<IEngagementActionContext | undefined>(undefined);

--- a/journeypoint/providers/engagementProvider/index.tsx
+++ b/journeypoint/providers/engagementProvider/index.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import React, { useContext, useReducer } from "react";
+import {
+    acknowledgeAtRiskFlag as acknowledgeAtRiskFlagRequest,
+    fetchHireIntelligence,
+    resolveAtRiskFlag as resolveAtRiskFlagRequest,
+} from "@/utils/engagement/provider";
+import {
+    getHireIntelligenceError,
+    getHireIntelligencePending,
+    getHireIntelligenceSuccess,
+    mutationError,
+    mutationPending,
+    mutationSuccess,
+    resetHireIntelligence as resetHireIntelligenceAction,
+} from "./actions";
+import {
+    EngagementActionContext,
+    EngagementStateContext,
+    INITIAL_STATE,
+    type IAcknowledgeAtRiskFlagRequest,
+    type IEngagementActionContext,
+    type IEngagementStateContext,
+    type IHireIntelligenceDetailDto,
+    type IResolveAtRiskFlagRequest,
+} from "./context";
+import { EngagementReducer } from "./reducer";
+
+/**
+ * Provides typed hire-intelligence and intervention state for facilitator views.
+ */
+export const EngagementProvider: React.FC<{ children: React.ReactNode }> = ({
+    children,
+}) => {
+    const [state, dispatch] = useReducer(EngagementReducer, INITIAL_STATE);
+
+    const getHireIntelligence = async (
+        hireId: string,
+    ): Promise<IHireIntelligenceDetailDto | null> => {
+        dispatch(getHireIntelligencePending());
+
+        try {
+            const selectedHireIntelligence = await fetchHireIntelligence(hireId);
+            dispatch(getHireIntelligenceSuccess(selectedHireIntelligence));
+            return selectedHireIntelligence;
+        } catch (error) {
+            console.error(error);
+            dispatch(getHireIntelligenceError());
+            return null;
+        }
+    };
+
+    const refreshAfterMutation = async (
+        hireId: string,
+    ): Promise<IHireIntelligenceDetailDto | null> => {
+        try {
+            const selectedHireIntelligence = await fetchHireIntelligence(hireId);
+            dispatch(mutationSuccess(selectedHireIntelligence));
+            return selectedHireIntelligence;
+        } catch (error) {
+            console.error(error);
+            dispatch(mutationError());
+            return null;
+        }
+    };
+
+    const acknowledgeAtRiskFlag = async (
+        hireId: string,
+        payload: IAcknowledgeAtRiskFlagRequest,
+    ): Promise<IHireIntelligenceDetailDto | null> => {
+        dispatch(mutationPending());
+
+        try {
+            await acknowledgeAtRiskFlagRequest(payload);
+            return await refreshAfterMutation(hireId);
+        } catch (error) {
+            console.error(error);
+            dispatch(mutationError());
+            return null;
+        }
+    };
+
+    const resolveAtRiskFlag = async (
+        hireId: string,
+        payload: IResolveAtRiskFlagRequest,
+    ): Promise<IHireIntelligenceDetailDto | null> => {
+        dispatch(mutationPending());
+
+        try {
+            await resolveAtRiskFlagRequest(payload);
+            return await refreshAfterMutation(hireId);
+        } catch (error) {
+            console.error(error);
+            dispatch(mutationError());
+            return null;
+        }
+    };
+
+    const resetHireIntelligence = (): void => {
+        dispatch(resetHireIntelligenceAction());
+    };
+
+    return (
+        <EngagementStateContext.Provider value={state}>
+            <EngagementActionContext.Provider
+                value={{
+                    getHireIntelligence,
+                    acknowledgeAtRiskFlag,
+                    resolveAtRiskFlag,
+                    resetHireIntelligence,
+                }}
+            >
+                {children}
+            </EngagementActionContext.Provider>
+        </EngagementStateContext.Provider>
+    );
+};
+
+export const useEngagementState = (): IEngagementStateContext => {
+    const context = useContext(EngagementStateContext);
+
+    if (context === undefined) {
+        throw new Error("useEngagementState must be used within an EngagementProvider");
+    }
+
+    return context;
+};
+
+export const useEngagementActions = (): IEngagementActionContext => {
+    const context = useContext(EngagementActionContext);
+
+    if (context === undefined) {
+        throw new Error("useEngagementActions must be used within an EngagementProvider");
+    }
+
+    return context;
+};

--- a/journeypoint/providers/engagementProvider/reducer.tsx
+++ b/journeypoint/providers/engagementProvider/reducer.tsx
@@ -1,0 +1,40 @@
+import { handleActions } from "redux-actions";
+import { INITIAL_STATE, type IEngagementStateContext } from "./context";
+import { EngagementActionEnums } from "./actions";
+
+export const EngagementReducer = handleActions<
+    IEngagementStateContext,
+    Partial<IEngagementStateContext>
+>(
+    {
+        [EngagementActionEnums.getHireIntelligencePending]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [EngagementActionEnums.getHireIntelligenceSuccess]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [EngagementActionEnums.getHireIntelligenceError]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [EngagementActionEnums.mutationPending]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [EngagementActionEnums.mutationSuccess]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [EngagementActionEnums.mutationError]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+        [EngagementActionEnums.resetHireIntelligence]: (state, action) => ({
+            ...state,
+            ...action.payload,
+        }),
+    },
+    INITIAL_STATE,
+);

--- a/journeypoint/types/engagement/components.ts
+++ b/journeypoint/types/engagement/components.ts
@@ -1,7 +1,57 @@
-import type { EngagementClassification } from "@/types/engagement";
+import type {
+    EngagementClassification,
+    IAcknowledgeAtRiskFlagRequest,
+    IAtRiskFlagDto,
+    IEngagementSnapshotDto,
+    IResolveAtRiskFlagRequest,
+} from "@/types/engagement";
 
 export interface IEngagementBadgeProps {
     classification: EngagementClassification;
+    compositeScore?: number;
     hasActiveAtRiskFlag?: boolean;
     compact?: boolean;
+}
+
+export interface IScoreTrendChartProps {
+    currentSnapshot?: IEngagementSnapshotDto | null;
+    snapshotHistory: IEngagementSnapshotDto[];
+}
+
+export interface IAtRiskFlagPanelProps {
+    activeFlag?: IAtRiskFlagDto | null;
+    isPending: boolean;
+    onAcknowledge: (payload: IAcknowledgeAtRiskFlagRequest) => Promise<boolean>;
+    onResolve: (payload: IResolveAtRiskFlagRequest) => Promise<boolean>;
+}
+
+export interface IInterventionHistoryPanelProps {
+    resolvedFlags: IAtRiskFlagDto[];
+}
+
+export interface ITrendChartPoint {
+    key: string;
+    x: number;
+    y: number;
+    value: number;
+    label: string;
+    tooltip: string;
+}
+
+export interface ITrendChartTick {
+    key: string;
+    x: number;
+    label: string;
+}
+
+export interface ITrendChartModel {
+    width: number;
+    points: ITrendChartPoint[];
+    ticks: ITrendChartTick[];
+    polylinePoints: string;
+    latestScore: number;
+    previousScore?: number;
+    lowestScore: number;
+    highestScore: number;
+    hasRepeatedSameDaySnapshots: boolean;
 }

--- a/journeypoint/types/engagement/index.ts
+++ b/journeypoint/types/engagement/index.ts
@@ -1,5 +1,80 @@
+import type { HireLifecycleState } from "@/types/hire";
+import type { JourneyStatus } from "@/types/journey";
+
 export enum EngagementClassification {
     Healthy = 1,
     NeedsAttention = 2,
     AtRisk = 3,
+}
+
+export enum AtRiskFlagStatus {
+    Active = 1,
+    Acknowledged = 2,
+    Resolved = 3,
+}
+
+export enum AtRiskResolutionType {
+    ManualFacilitatorResolution = 1,
+    AutomaticHealthyRecovery = 2,
+    HireExited = 3,
+}
+
+export interface IEngagementSnapshotDto {
+    id: string;
+    completionRate: number;
+    daysSinceLastActivity: number;
+    overdueTaskCount: number;
+    compositeScore: number;
+    classification: EngagementClassification;
+    computedAt: string;
+}
+
+export interface IAtRiskFlagDto {
+    id: string;
+    hireId: string;
+    journeyId: string;
+    status: AtRiskFlagStatus;
+    raisedAt: string;
+    classificationAtRaise: EngagementClassification;
+    acknowledgedByUserId?: number | null;
+    acknowledgedByDisplayName?: string | null;
+    acknowledgedAt?: string | null;
+    acknowledgementNotes?: string | null;
+    resolvedByUserId?: number | null;
+    resolvedByDisplayName?: string | null;
+    resolvedAt?: string | null;
+    resolutionType?: AtRiskResolutionType | null;
+    resolutionNotes?: string | null;
+}
+
+export interface IHireIntelligenceDetailDto {
+    hireId: string;
+    journeyId?: string | null;
+    onboardingPlanId: string;
+    onboardingPlanName: string;
+    managerUserId?: number | null;
+    managerDisplayName?: string | null;
+    fullName: string;
+    emailAddress: string;
+    roleTitle?: string | null;
+    department?: string | null;
+    startDate: string;
+    hireStatus: HireLifecycleState;
+    journeyStatus?: JourneyStatus | null;
+    currentStageTitle?: string | null;
+    currentSnapshot?: IEngagementSnapshotDto | null;
+    snapshotHistory: IEngagementSnapshotDto[];
+    activeFlag?: IAtRiskFlagDto | null;
+    resolvedFlags: IAtRiskFlagDto[];
+}
+
+export interface IAcknowledgeAtRiskFlagRequest {
+    flagId: string;
+    acknowledgementNotes?: string | null;
+}
+
+export interface IResolveAtRiskFlagRequest {
+    flagId: string;
+    resolutionType: AtRiskResolutionType;
+    resolutionNotes?: string | null;
 }

--- a/journeypoint/types/pipeline/components.ts
+++ b/journeypoint/types/pipeline/components.ts
@@ -1,12 +1,6 @@
-import type {
-    EngagementClassification,
-    IPipelineBoardDto,
-    IPipelineColumnDto,
-    IPipelineHireCardDto,
-} from "@/types/pipeline";
-
+import type { EngagementClassification } from "@/types/engagement";
+import type { IPipelineBoardDto, IPipelineColumnDto, IPipelineHireCardDto } from "@/types/pipeline";
 export type IPipelineBoardViewProps = Record<string, never>;
-
 export interface IPipelineKanbanProps {
     columns: IPipelineColumnDto[];
     onOpenHire: (hireId: string) => void;

--- a/journeypoint/types/pipeline/index.ts
+++ b/journeypoint/types/pipeline/index.ts
@@ -1,8 +1,4 @@
-export enum EngagementClassification {
-    Healthy = 1,
-    NeedsAttention = 2,
-    AtRisk = 3,
-}
+import type { EngagementClassification } from "@/types/engagement";
 
 export interface IGetPipelineBoardInput {
     keyword?: string | null;

--- a/journeypoint/utils/engagement/chart.ts
+++ b/journeypoint/utils/engagement/chart.ts
@@ -1,0 +1,172 @@
+import type { IEngagementSnapshotDto } from "@/types/engagement";
+import type {
+    ITrendChartModel,
+    ITrendChartPoint,
+    ITrendChartTick,
+} from "@/types/engagement/components";
+import { formatDisplayDate, formatDisplayDateTime } from "@/utils/date";
+
+const CHART_HEIGHT = 180;
+const CHART_PADDING = 24;
+const CHART_MIN_WIDTH = 520;
+const CHART_POINT_SPACING = 88;
+const MIN_DOMAIN = 0;
+const MAX_DOMAIN = 100;
+
+const DATE_KEY_FORMATTER = new Intl.DateTimeFormat("en-ZA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+});
+
+const sortSnapshotsAscending = (
+    snapshots: IEngagementSnapshotDto[],
+): IEngagementSnapshotDto[] =>
+    [...snapshots].sort(
+        (leftSnapshot, rightSnapshot) =>
+            new Date(leftSnapshot.computedAt).getTime() -
+            new Date(rightSnapshot.computedAt).getTime(),
+    );
+
+const getChartWidth = (totalCount: number): number =>
+    Math.max(CHART_MIN_WIDTH, totalCount * CHART_POINT_SPACING);
+
+const getDateKey = (value: string): string => DATE_KEY_FORMATTER.format(new Date(value));
+
+const hasRepeatedSameDaySnapshots = (snapshots: IEngagementSnapshotDto[]): boolean => {
+    const keys = snapshots.map((snapshot) => getDateKey(snapshot.computedAt));
+    return new Set(keys).size !== keys.length;
+};
+
+const getPointLabel = (
+    snapshot: IEngagementSnapshotDto,
+    showTimeGranularity: boolean,
+): string => (showTimeGranularity ? formatDisplayDateTime(snapshot.computedAt) : formatDisplayDate(snapshot.computedAt));
+
+const getTickIndexes = (totalCount: number): number[] => {
+    if (totalCount <= 4) {
+        return Array.from({ length: totalCount }, (_, index) => index);
+    }
+
+    const rawIndexes = [
+        0,
+        Math.floor((totalCount - 1) / 3),
+        Math.floor(((totalCount - 1) * 2) / 3),
+        totalCount - 1,
+    ];
+
+    return [...new Set(rawIndexes)].sort((leftIndex, rightIndex) => leftIndex - rightIndex);
+};
+
+const mapPoint = (
+    snapshot: IEngagementSnapshotDto,
+    index: number,
+    totalCount: number,
+    chartWidth: number,
+    showTimeGranularity: boolean,
+): ITrendChartPoint => {
+    const usableWidth = chartWidth - CHART_PADDING * 2;
+    const usableHeight = CHART_HEIGHT - CHART_PADDING * 2;
+    const x =
+        totalCount === 1
+            ? chartWidth / 2
+            : CHART_PADDING + (usableWidth / (totalCount - 1)) * index;
+    const normalizedValue = (snapshot.compositeScore - MIN_DOMAIN) / (MAX_DOMAIN - MIN_DOMAIN);
+    const y = CHART_HEIGHT - CHART_PADDING - usableHeight * normalizedValue;
+
+    return {
+        key: snapshot.id,
+        x,
+        y,
+        value: snapshot.compositeScore,
+        label: getPointLabel(snapshot, showTimeGranularity),
+        tooltip: `${getPointLabel(snapshot, true)} - ${Math.round(snapshot.compositeScore)}%`,
+    };
+};
+
+const mapTicks = (
+    points: ITrendChartPoint[],
+    totalCount: number,
+): ITrendChartTick[] =>
+    getTickIndexes(totalCount).map((index) => ({
+        key: points[index].key,
+        x: points[index].x,
+        label: points[index].label,
+    }));
+
+export const getTrendChartModel = (
+    currentSnapshot: IEngagementSnapshotDto | null | undefined,
+    snapshotHistory: IEngagementSnapshotDto[],
+): ITrendChartModel | null => {
+    const history = currentSnapshot
+        ? snapshotHistory.some((snapshot) => snapshot.id === currentSnapshot.id)
+            ? snapshotHistory
+            : [...snapshotHistory, currentSnapshot]
+        : snapshotHistory;
+    const orderedSnapshots = sortSnapshotsAscending(history);
+
+    if (orderedSnapshots.length === 0) {
+        return null;
+    }
+
+    const repeatedSameDaySnapshots = hasRepeatedSameDaySnapshots(orderedSnapshots);
+    const chartWidth = getChartWidth(orderedSnapshots.length);
+    const points = orderedSnapshots.map((snapshot, index) =>
+        mapPoint(
+            snapshot,
+            index,
+            orderedSnapshots.length,
+            chartWidth,
+            repeatedSameDaySnapshots,
+        ),
+    );
+    const scores = orderedSnapshots.map((snapshot) => snapshot.compositeScore);
+    const polylinePoints = points.map((point) => `${point.x},${point.y}`).join(" ");
+    const latestScore = orderedSnapshots[orderedSnapshots.length - 1].compositeScore;
+    const previousScore =
+        orderedSnapshots.length > 1
+            ? orderedSnapshots[orderedSnapshots.length - 2].compositeScore
+            : undefined;
+
+    return {
+        width: chartWidth,
+        points,
+        ticks: mapTicks(points, orderedSnapshots.length),
+        polylinePoints,
+        latestScore,
+        previousScore,
+        lowestScore: Math.min(...scores),
+        highestScore: Math.max(...scores),
+        hasRepeatedSameDaySnapshots: repeatedSameDaySnapshots,
+    };
+};
+
+export const getTrendDeltaLabel = (model: ITrendChartModel | null): string => {
+    if (!model || model.previousScore === undefined) {
+        return "No previous comparison yet";
+    }
+
+    const delta = Math.round(model.latestScore - model.previousScore);
+
+    if (delta === 0) {
+        return "Stable since the last snapshot";
+    }
+
+    return delta > 0 ? `Up ${delta} points` : `Down ${Math.abs(delta)} points`;
+};
+
+export const TREND_GRID_LINES = [0, 50, 100].map((value) => {
+    const usableHeight = CHART_HEIGHT - CHART_PADDING * 2;
+    const normalizedValue = (value - MIN_DOMAIN) / (MAX_DOMAIN - MIN_DOMAIN);
+
+    return {
+        key: value,
+        label: `${value}`,
+        y: CHART_HEIGHT - CHART_PADDING - usableHeight * normalizedValue,
+    };
+});
+
+export const TREND_CHART_DIMENSIONS = {
+    height: CHART_HEIGHT,
+    padding: CHART_PADDING,
+};

--- a/journeypoint/utils/engagement/provider.ts
+++ b/journeypoint/utils/engagement/provider.ts
@@ -1,0 +1,47 @@
+import { getAxiosInstance } from "@/utils/axiosInstance";
+import type {
+    IAcknowledgeAtRiskFlagRequest,
+    IAtRiskFlagDto,
+    IHireIntelligenceDetailDto,
+    IResolveAtRiskFlagRequest,
+} from "@/types/engagement";
+
+const ENGAGEMENT_API_BASE = "/api/services/app/Engagement";
+
+const getEngagementApiResult = <T,>(response: { data?: { result?: T } & T }): T =>
+    response.data?.result ?? (response.data as T);
+
+export const fetchHireIntelligence = async (
+    hireId: string,
+): Promise<IHireIntelligenceDetailDto> => {
+    const response = await getAxiosInstance().get(
+        `${ENGAGEMENT_API_BASE}/GetHireIntelligence`,
+        {
+            params: { hireId },
+        },
+    );
+
+    return getEngagementApiResult<IHireIntelligenceDetailDto>(response);
+};
+
+export const acknowledgeAtRiskFlag = async (
+    payload: IAcknowledgeAtRiskFlagRequest,
+): Promise<IAtRiskFlagDto> => {
+    const response = await getAxiosInstance().post(
+        `${ENGAGEMENT_API_BASE}/AcknowledgeAtRiskFlag`,
+        payload,
+    );
+
+    return getEngagementApiResult<IAtRiskFlagDto>(response);
+};
+
+export const resolveAtRiskFlag = async (
+    payload: IResolveAtRiskFlagRequest,
+): Promise<IAtRiskFlagDto> => {
+    const response = await getAxiosInstance().post(
+        `${ENGAGEMENT_API_BASE}/ResolveAtRiskFlag`,
+        payload,
+    );
+
+    return getEngagementApiResult<IAtRiskFlagDto>(response);
+};

--- a/specs/001-journeypoint-platform/tasks.md
+++ b/specs/001-journeypoint-platform/tasks.md
@@ -194,10 +194,10 @@ engagement data, surfaces at-risk hires, and supports facilitator intervention.
 - [x] T047 [US5] Implement engagement scoring domain service in `aspnet-core/src/JourneyPoint.Core/Domains/Engagement/EngagementScoreService.cs`
 - [x] T048 [US5] Implement pipeline, hire intelligence, and intervention services in `aspnet-core/src/JourneyPoint.Application/Services/EngagementService/`
 - [x] T049 [P] [US5] Build facilitator pipeline page in `journeypoint/app/(facilitator)/pipeline/page.tsx`
-- [ ] T050 [P] [US5] Add engagement and pipeline provider state in `journeypoint/providers/engagementProvider/` and `journeypoint/providers/pipelineProvider/`
-- [ ] T051 [P] [US5] Build intelligence components in `journeypoint/components/pipeline/PipelineKanban.tsx`, `PipelineColumn.tsx`, `HirePipelineCard.tsx`, `journeypoint/components/engagement/EngagementBadge.tsx`, `AtRiskFlagPanel.tsx`, and `journeypoint/components/journey/ScoreTrendChart.tsx`
+- [x] T050 [P] [US5] Add engagement and pipeline provider state in `journeypoint/providers/engagementProvider/` and `journeypoint/providers/pipelineProvider/`
+- [x] T051 [P] [US5] Build intelligence components in `journeypoint/components/pipeline/PipelineKanban.tsx`, `PipelineColumn.tsx`, `HirePipelineCard.tsx`, `journeypoint/components/engagement/EngagementBadge.tsx`, `AtRiskFlagPanel.tsx`, and `journeypoint/components/journey/ScoreTrendChart.tsx`
 - [ ] T052 [US5] Seed Boxfusion and DeptDemo demo data in `aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/`
-- [ ] T053 [US5] Add facilitator intervention capture and flag history UI in `journeypoint/app/(facilitator)/hires/[hireId]/page.tsx`
+- [x] T053 [US5] Add facilitator intervention capture and flag history UI in `journeypoint/app/(facilitator)/hires/[hireId]/page.tsx`
 
 **Checkpoint**: Intelligence, flags, pipeline, and intervention flows are demonstrable.
 


### PR DESCRIPTION
Linking Issues #41 

This pull request introduces new engagement-related components and integrates them into the hire detail view, enhancing the display and management of at-risk interventions and engagement history for hires. It also updates the styling approach for engagement components and improves state management by utilizing new context providers.

**Integration of engagement panels and state:**

* Added `AtRiskFlagPanel`, `InterventionHistoryPanel`, and `EngagementBadge` components to the `HireDetailView`, allowing facilitators to view and manage active at-risk flags and intervention history directly from the hire detail page. [[1]](diffhunk://#diff-f405043d4650feaa2145cd891f8dc052f1956b0feabf4df4a5e4c3660f9d762eR1-R208) [[2]](diffhunk://#diff-4b3a168cc040d1480f9e9eaea1771fc5125ee0fd18f79df7bf2876b994936374R1-R93) [[3]](diffhunk://#diff-7704d1495434e74950b3b59e82212693d7fbd32c7672d362c64e3e1571fc9c3aR16-R19) [[4]](diffhunk://#diff-7704d1495434e74950b3b59e82212693d7fbd32c7672d362c64e3e1571fc9c3aR131-R145)
* Integrated `EngagementProvider` into the facilitator hire detail page and updated state management in `HireDetailView` to use engagement actions and state, enabling fetching and mutation of engagement intelligence alongside hire details. ([journeypoint/app/(facilitator)/facilitator/hires/[hireId]/page.tsxR11](diffhunk://#diff-fef17b4f2d9c73f2bd8adffd4d423673200f27c109e5799a2430c7f6737afb8cR11), [journeypoint/app/(facilitator)/facilitator/hires/[hireId]/page.tsxR23-R25](diffhunk://#diff-fef17b4f2d9c73f2bd8adffd4d423673200f27c109e5799a2430c7f6737afb8cR23-R25), [[1]](diffhunk://#diff-7704d1495434e74950b3b59e82212693d7fbd32c7672d362c64e3e1571fc9c3aR33-R41) [[2]](diffhunk://#diff-7704d1495434e74950b3b59e82212693d7fbd32c7672d362c64e3e1571fc9c3aR55-R70) [[3]](diffhunk://#diff-7704d1495434e74950b3b59e82212693d7fbd32c7672d362c64e3e1571fc9c3aL62-R82) [[4]](diffhunk://#diff-7704d1495434e74950b3b59e82212693d7fbd32c7672d362c64e3e1571fc9c3aL71-R108)

**Component and type refactoring:**

* Refactored `EngagementBadge` to use engagement-specific constants/types and added a `compact` display mode for more flexible rendering. [[1]](diffhunk://#diff-e002675539feb7db983a46ca59cf27ea4b6b6e7af8be66a362584b2bc83b2f51R6-R10) [[2]](diffhunk://#diff-e002675539feb7db983a46ca59cf27ea4b6b6e7af8be66a362584b2bc83b2f51R20-R29)

**Styling improvements:**

* Introduced a new `useStyles` hook using `antd-style` for consistent and modular CSS-in-JS styling across engagement components.

These changes collectively provide a more robust and interactive experience for facilitators managing hire engagement and interventions, with improved UI consistency and state handling.