### PR TITLE
feat: Implement demo tenant data seeding and validation

### DIFF
--- a/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/SeedHelper.cs
+++ b/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/SeedHelper.cs
@@ -27,6 +27,7 @@ namespace JourneyPoint.EntityFrameworkCore.Seed
             // Default tenant seed (in host database).
             new DefaultTenantBuilder(context).Create();
             new TenantRoleAndUserBuilder(context, 1).Create();
+            new DemoTenantSeedOrchestrator(context).Create();
         }
 
         private static void WithDbContext<TDbContext>(IIocResolver iocResolver, Action<TDbContext> contextAction)

--- a/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/BoxfusionDemoDataBuilder.cs
+++ b/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/BoxfusionDemoDataBuilder.cs
@@ -1,0 +1,147 @@
+using System;
+using JourneyPoint.Authorization.Roles;
+using JourneyPoint.Authorization.Users;
+using JourneyPoint.Domains.Engagement;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+using JourneyPoint.MultiTenancy;
+
+namespace JourneyPoint.EntityFrameworkCore.Seed.Tenants
+{
+    /// <summary>
+    /// Seeds the Boxfusion tenant with milestone-ready demo onboarding data.
+    /// </summary>
+    public class BoxfusionDemoDataBuilder : DemoTenantDataBuilderBase
+    {
+        /// <summary>
+        /// Initializes the Boxfusion demo-data builder.
+        /// </summary>
+        public BoxfusionDemoDataBuilder(JourneyPointDbContext context, Tenant tenant)
+            : base(context, tenant)
+        {
+        }
+
+        /// <summary>
+        /// Creates the Boxfusion facilitator, manager, hire, journey, and engagement demo state.
+        /// </summary>
+        public override void Create()
+        {
+            var manager = EnsureUser("manager.boxfusion", "manager@boxfusion.demo", "Lerato", "Khumalo", StaticRoleNames.Tenants.Manager);
+            EnsureUser("facilitator.boxfusion", "facilitator@boxfusion.demo", "Tandi", "Meyer", StaticRoleNames.Tenants.Facilitator);
+            var alexUser = EnsureUser("alex.boxfusion", "alex@boxfusion.demo", "Alex", "Mokoena", StaticRoleNames.Tenants.Enrolee);
+            var nomsaUser = EnsureUser("nomsa.boxfusion", "nomsa@boxfusion.demo", "Nomsa", "Jacobs", StaticRoleNames.Tenants.Enrolee);
+            var thaboUser = EnsureUser("thabo.boxfusion", "thabo@boxfusion.demo", "Thabo", "Ndlovu", StaticRoleNames.Tenants.Enrolee);
+
+            var plan = EnsurePublishedPlan(
+                "Boxfusion Graduate Accelerator",
+                "A reusable graduate onboarding programme for customer-facing consulting teams.",
+                "Graduate hires",
+                21);
+
+            var welcomeModule = EnsureModule(plan, 1, "Welcome & Foundations", "Anchor the hire in the programme, values, and first-week context.");
+            var integrationModule = EnsureModule(plan, 2, "Team Integration", "Connect the hire with their manager, onboarding buddy, and team rituals.");
+            var practiceModule = EnsureModule(plan, 3, "Guided Practice", "Move the hire into structured learning and coached execution.");
+            var capabilityModule = EnsureModule(plan, 4, "Capability Check", "Confirm readiness through review and capstone reflection.");
+
+            var welcomeChecklist = EnsureTemplateTask(welcomeModule, 1, "Complete welcome checklist", "Finish the day-one admin, tooling, and workspace setup checklist.", OnboardingTaskCategory.Orientation, 0, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.NotRequired);
+            var cultureGuide = EnsureTemplateTask(welcomeModule, 2, "Review culture guide", "Read and acknowledge the Boxfusion culture and consulting expectations guide.", OnboardingTaskCategory.Learning, 1, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.Required);
+            var kickoffCheckIn = EnsureTemplateTask(integrationModule, 1, "Manager kickoff check-in", "Meet with the direct manager to align on success measures and support needs.", OnboardingTaskCategory.CheckIn, 2, OnboardingTaskAssignmentTarget.Manager, OnboardingTaskAcknowledgementRule.NotRequired);
+            var onboardingBuddy = EnsureTemplateTask(integrationModule, 2, "Meet your onboarding buddy", "Book a guided handover with the nominated onboarding buddy.", OnboardingTaskCategory.Practice, 4, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.NotRequired);
+            var sandboxExercise = EnsureTemplateTask(practiceModule, 1, "Complete sandbox exercise", "Work through the first sandbox delivery simulation with facilitator notes.", OnboardingTaskCategory.Practice, 6, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.NotRequired);
+            var reflection = EnsureTemplateTask(practiceModule, 2, "Submit first-week reflection", "Capture progress, blockers, and confidence after the first practice sprint.", OnboardingTaskCategory.Assessment, 8, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.Required);
+            var managerReview = EnsureTemplateTask(capabilityModule, 1, "Manager progress review", "Review readiness signals and unblock any remaining onboarding issues.", OnboardingTaskCategory.CheckIn, 10, OnboardingTaskAssignmentTarget.Manager, OnboardingTaskAcknowledgementRule.NotRequired);
+            var capstoneRecap = EnsureTemplateTask(capabilityModule, 2, "Present capstone recap", "Share the capstone recap and key takeaways with the facilitator.", OnboardingTaskCategory.Assessment, 12, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.NotRequired);
+
+            SeedEngagedHire(plan, manager, alexUser, welcomeModule, integrationModule, practiceModule, capabilityModule, welcomeChecklist, cultureGuide, kickoffCheckIn, onboardingBuddy, sandboxExercise, reflection, managerReview, capstoneRecap);
+            SeedNeedsAttentionHire(plan, manager, nomsaUser, welcomeModule, integrationModule, practiceModule, capabilityModule, welcomeChecklist, cultureGuide, kickoffCheckIn, onboardingBuddy, sandboxExercise, reflection, managerReview, capstoneRecap);
+            SeedAtRiskHire(plan, manager, thaboUser, welcomeModule, integrationModule, practiceModule, capabilityModule, welcomeChecklist, cultureGuide, kickoffCheckIn, onboardingBuddy, sandboxExercise, reflection, managerReview, capstoneRecap);
+        }
+
+        private void SeedEngagedHire(OnboardingPlan plan, User manager, User enrolee, OnboardingModule welcomeModule, OnboardingModule integrationModule, OnboardingModule practiceModule, OnboardingModule capabilityModule, OnboardingTask welcomeChecklist, OnboardingTask cultureGuide, OnboardingTask kickoffCheckIn, OnboardingTask onboardingBuddy, OnboardingTask sandboxExercise, OnboardingTask reflection, OnboardingTask managerReview, OnboardingTask capstoneRecap)
+        {
+            var today = DateTime.UtcNow.Date;
+            var startDate = today.AddDays(-7);
+            var hire = EnsureHire(plan, enrolee, manager, "Alex Mokoena", enrolee.EmailAddress, "Associate Consultant", "Customer Success", startDate, HireLifecycleState.Active, WelcomeNotificationStatus.Sent, startDate, startDate, null, startDate, null);
+            var journey = EnsureJourney(hire, plan, JourneyStatus.Active, startDate, null);
+
+            EnsureJourneyTask(journey, startDate, welcomeChecklist, welcomeModule, welcomeChecklist.Title, welcomeChecklist.Description, JourneyTaskStatus.Completed, null, startDate, enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, cultureGuide, welcomeModule, cultureGuide.Title, cultureGuide.Description, JourneyTaskStatus.Completed, startDate.AddDays(1), startDate.AddDays(1), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, kickoffCheckIn, integrationModule, kickoffCheckIn.Title, kickoffCheckIn.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(2), manager.Id, null);
+            EnsureJourneyTask(journey, startDate, onboardingBuddy, integrationModule, onboardingBuddy.Title, onboardingBuddy.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(3), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, sandboxExercise, practiceModule, practiceModule.Name + " sandbox exercise", sandboxExercise.Description, JourneyTaskStatus.Completed, null, today.AddDays(-1), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, reflection, practiceModule, reflection.Title, reflection.Description, JourneyTaskStatus.Pending, null, null, null, today.AddDays(-1));
+            EnsureJourneyTask(journey, startDate, managerReview, capabilityModule, managerReview.Title, managerReview.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, capstoneRecap, capabilityModule, capstoneRecap.Title, capstoneRecap.Description, JourneyTaskStatus.Pending, null, null, null, null);
+
+            EnsureHistoricalSnapshots(hire, journey, new[]
+            {
+                new SnapshotSeed(12.5m, 6, 3, 26.39m, EngagementClassification.AtRisk, today.AddDays(-10).AddHours(10)),
+                new SnapshotSeed(37.5m, 3, 2, 51.07m, EngagementClassification.NeedsAttention, today.AddDays(-7).AddHours(10)),
+                new SnapshotSeed(50m, 2, 1, 68.21m, EngagementClassification.NeedsAttention, today.AddDays(-4).AddHours(10)),
+                new SnapshotSeed(62.5m, 1, 0, 79.11m, EngagementClassification.Healthy, today.AddDays(-2).AddHours(10))
+            });
+
+            EnsureResolvedFlag(
+                hire,
+                journey,
+                today.AddDays(-10).AddHours(9),
+                today.AddDays(-9).AddHours(8),
+                today.AddDays(-3).AddHours(16),
+                manager.Id,
+                manager.Id,
+                "Manager scheduled a focused support cadence after the first-week check-in.",
+                "Recovered after focused coaching and completion of the guided practice backlog.",
+                AtRiskResolutionType.ManualFacilitatorResolution);
+        }
+
+        private void SeedNeedsAttentionHire(OnboardingPlan plan, User manager, User enrolee, OnboardingModule welcomeModule, OnboardingModule integrationModule, OnboardingModule practiceModule, OnboardingModule capabilityModule, OnboardingTask welcomeChecklist, OnboardingTask cultureGuide, OnboardingTask kickoffCheckIn, OnboardingTask onboardingBuddy, OnboardingTask sandboxExercise, OnboardingTask reflection, OnboardingTask managerReview, OnboardingTask capstoneRecap)
+        {
+            var today = DateTime.UtcNow.Date;
+            var startDate = today.AddDays(-8);
+            var hire = EnsureHire(plan, enrolee, manager, "Nomsa Jacobs", enrolee.EmailAddress, "Business Analyst", "Advisory", startDate, HireLifecycleState.Active, WelcomeNotificationStatus.Sent, startDate, startDate, null, startDate, null);
+            var journey = EnsureJourney(hire, plan, JourneyStatus.Active, startDate, null);
+
+            EnsureJourneyTask(journey, startDate, welcomeChecklist, welcomeModule, welcomeChecklist.Title, welcomeChecklist.Description, JourneyTaskStatus.Completed, null, startDate, enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, cultureGuide, welcomeModule, cultureGuide.Title, cultureGuide.Description, JourneyTaskStatus.Completed, startDate.AddDays(1), startDate.AddDays(1), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, kickoffCheckIn, integrationModule, kickoffCheckIn.Title, kickoffCheckIn.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(2), manager.Id, null);
+            EnsureJourneyTask(journey, startDate, onboardingBuddy, integrationModule, onboardingBuddy.Title, onboardingBuddy.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(3), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, sandboxExercise, practiceModule, sandboxExercise.Title, sandboxExercise.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, reflection, practiceModule, reflection.Title, reflection.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, managerReview, capabilityModule, managerReview.Title, managerReview.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, capstoneRecap, capabilityModule, capstoneRecap.Title, capstoneRecap.Description, JourneyTaskStatus.Pending, null, null, null, null);
+
+            EnsureHistoricalSnapshots(hire, journey, new[]
+            {
+                new SnapshotSeed(50m, 1, 0, 75m, EngagementClassification.Healthy, today.AddDays(-9).AddHours(9)),
+                new SnapshotSeed(50m, 3, 0, 70.71m, EngagementClassification.NeedsAttention, today.AddDays(-6).AddHours(9)),
+                new SnapshotSeed(50m, 5, 1, 59.29m, EngagementClassification.NeedsAttention, today.AddDays(-3).AddHours(9))
+            });
+        }
+
+        private void SeedAtRiskHire(OnboardingPlan plan, User manager, User enrolee, OnboardingModule welcomeModule, OnboardingModule integrationModule, OnboardingModule practiceModule, OnboardingModule capabilityModule, OnboardingTask welcomeChecklist, OnboardingTask cultureGuide, OnboardingTask kickoffCheckIn, OnboardingTask onboardingBuddy, OnboardingTask sandboxExercise, OnboardingTask reflection, OnboardingTask managerReview, OnboardingTask capstoneRecap)
+        {
+            var today = DateTime.UtcNow.Date;
+            var startDate = today.AddDays(-14);
+            var hire = EnsureHire(plan, enrolee, manager, "Thabo Ndlovu", enrolee.EmailAddress, "Implementation Analyst", "Delivery", startDate, HireLifecycleState.Active, WelcomeNotificationStatus.Sent, startDate, startDate, null, startDate, null);
+            var journey = EnsureJourney(hire, plan, JourneyStatus.Active, startDate, null);
+
+            EnsureJourneyTask(journey, startDate, welcomeChecklist, welcomeModule, welcomeChecklist.Title, welcomeChecklist.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(2), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, cultureGuide, welcomeModule, cultureGuide.Title, cultureGuide.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, kickoffCheckIn, integrationModule, kickoffCheckIn.Title, kickoffCheckIn.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, onboardingBuddy, integrationModule, onboardingBuddy.Title, onboardingBuddy.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, sandboxExercise, practiceModule, sandboxExercise.Title, sandboxExercise.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, reflection, practiceModule, reflection.Title, reflection.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, managerReview, capabilityModule, managerReview.Title, managerReview.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, capstoneRecap, capabilityModule, capstoneRecap.Title, capstoneRecap.Description, JourneyTaskStatus.Pending, null, null, null, null);
+
+            EnsureHistoricalSnapshots(hire, journey, new[]
+            {
+                new SnapshotSeed(37.5m, 4, 2, 48.93m, EngagementClassification.AtRisk, today.AddDays(-9).AddHours(11)),
+                new SnapshotSeed(25m, 7, 4, 26.79m, EngagementClassification.AtRisk, today.AddDays(-5).AddHours(11)),
+                new SnapshotSeed(12.5m, 11, 6, 12.68m, EngagementClassification.AtRisk, today.AddDays(-2).AddHours(11))
+            });
+
+            EnsureActiveFlag(hire, journey, today.AddDays(-2).AddHours(11));
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoSeedValidator.cs
+++ b/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoSeedValidator.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JourneyPoint.Domains.Engagement;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace JourneyPoint.EntityFrameworkCore.Seed.Tenants
+{
+    /// <summary>
+    /// Verifies that demo-tenant seed data satisfies the milestone walkthrough expectations.
+    /// </summary>
+    public class DemoSeedValidator
+    {
+        private readonly JourneyPointDbContext _context;
+        private readonly EngagementScoreService _engagementScoreService;
+
+        /// <summary>
+        /// Initializes the demo-seed validator.
+        /// </summary>
+        public DemoSeedValidator(JourneyPointDbContext context)
+        {
+            _context = context;
+            _engagementScoreService = new EngagementScoreService();
+        }
+
+        /// <summary>
+        /// Validates that the seeded demo tenants expose the expected JourneyPoint product loop.
+        /// </summary>
+        public void Validate()
+        {
+            ValidateBoxfusion();
+            ValidateDeptDemo();
+        }
+
+        private void ValidateBoxfusion()
+        {
+            var tenant = GetTenant("boxfusion");
+            var hires = GetTenantHires(tenant.Id);
+
+            if (hires.Count < 3)
+            {
+                throw new InvalidOperationException("Boxfusion demo seed must contain at least three hires.");
+            }
+
+            var classifications = hires
+                .Where(hire => hire.Journey != null && hire.Journey.Status == JourneyStatus.Active)
+                .ToDictionary(hire => hire.FullName, ComputeClassification);
+
+            EnsureClassification(classifications, "Alex Mokoena", EngagementClassification.Healthy);
+            EnsureClassification(classifications, "Nomsa Jacobs", EngagementClassification.NeedsAttention);
+            EnsureClassification(classifications, "Thabo Ndlovu", EngagementClassification.AtRisk);
+
+            var unresolvedFlagCount = _context.AtRiskFlags
+                .IgnoreQueryFilters()
+                .Count(flag => flag.TenantId == tenant.Id && flag.Status != AtRiskFlagStatus.Resolved);
+
+            var resolvedFlagCount = _context.AtRiskFlags
+                .IgnoreQueryFilters()
+                .Count(flag => flag.TenantId == tenant.Id && flag.Status == AtRiskFlagStatus.Resolved);
+
+            if (unresolvedFlagCount < 1 || resolvedFlagCount < 1)
+            {
+                throw new InvalidOperationException("Boxfusion demo seed must contain both unresolved and resolved intervention history.");
+            }
+
+            var hasManagerTasks = hires.Any(hire =>
+                hire.Journey?.Tasks.Any(task => task.AssignmentTarget == Domains.OnboardingPlans.OnboardingTaskAssignmentTarget.Manager) == true);
+
+            if (!hasManagerTasks)
+            {
+                throw new InvalidOperationException("Boxfusion demo seed must contain manager-assigned tasks for direct-report validation.");
+            }
+        }
+
+        private void ValidateDeptDemo()
+        {
+            var tenant = GetTenant("deptdemo");
+            var hires = GetTenantHires(tenant.Id);
+
+            if (!hires.Any(hire => hire.Status == HireLifecycleState.PendingActivation && hire.Journey?.Status == JourneyStatus.Draft))
+            {
+                throw new InvalidOperationException("DeptDemo demo seed must contain a pending-activation hire with a draft journey.");
+            }
+
+            if (!hires.Any(hire => hire.Status == HireLifecycleState.Completed && hire.Journey?.Status == JourneyStatus.Completed))
+            {
+                throw new InvalidOperationException("DeptDemo demo seed must contain a completed hire journey for completion-stage validation.");
+            }
+
+            if (!hires.Any(hire => hire.WelcomeNotificationStatus == WelcomeNotificationStatus.FailedRecoverable))
+            {
+                throw new InvalidOperationException("DeptDemo demo seed must retain a recoverable welcome-notification failure scenario.");
+            }
+        }
+
+        private Tenant GetTenant(string tenancyName)
+        {
+            var tenant = _context.Tenants
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingTenant => existingTenant.TenancyName == tenancyName);
+
+            return tenant ?? throw new InvalidOperationException($"Demo tenant '{tenancyName}' was not created.");
+        }
+
+        private List<Hire> GetTenantHires(int tenantId)
+        {
+            return _context.Hires
+                .IgnoreQueryFilters()
+                .Include(hire => hire.Journey)
+                    .ThenInclude(journey => journey.Tasks)
+                .Where(hire => hire.TenantId == tenantId)
+                .ToList();
+        }
+
+        private EngagementClassification ComputeClassification(Hire hire)
+        {
+            var tasks = hire.Journey.Tasks
+                .OrderBy(task => task.ModuleOrderIndex)
+                .ThenBy(task => task.TaskOrderIndex)
+                .ToList();
+
+            var lastActivityAt = tasks
+                .SelectMany(task => new[] { task.AcknowledgedAt, task.CompletedAt })
+                .Where(timestamp => timestamp.HasValue)
+                .Select(timestamp => timestamp!.Value)
+                .DefaultIfEmpty(hire.StartDate)
+                .Max();
+
+            var input = new EngagementScoreInput
+            {
+                TotalTaskCount = tasks.Count,
+                CompletedTaskCount = tasks.Count(task => task.Status == JourneyTaskStatus.Completed),
+                OverdueTaskCount = tasks.Count(task => task.Status == JourneyTaskStatus.Pending && task.DueOn.Date < DateTime.UtcNow.Date),
+                DaysSinceLastActivity = Math.Max(0, (DateTime.UtcNow.Date - lastActivityAt.Date).Days),
+                ComputedAt = DateTime.UtcNow
+            };
+
+            return _engagementScoreService.Calculate(input).Classification;
+        }
+
+        private static void EnsureClassification(IReadOnlyDictionary<string, EngagementClassification> classifications, string hireName, EngagementClassification expectedClassification)
+        {
+            if (!classifications.TryGetValue(hireName, out var actualClassification) || actualClassification != expectedClassification)
+            {
+                throw new InvalidOperationException($"Demo hire '{hireName}' should score as '{expectedClassification}'.");
+            }
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoTenantDataBuilderBase.Engagement.cs
+++ b/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoTenantDataBuilderBase.Engagement.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JourneyPoint.Domains.Engagement;
+using JourneyPoint.Domains.Hires;
+using Microsoft.EntityFrameworkCore;
+
+namespace JourneyPoint.EntityFrameworkCore.Seed.Tenants
+{
+    /// <summary>
+    /// Provides engagement-history helpers for tenant-scoped demo data builders.
+    /// </summary>
+    public abstract partial class DemoTenantDataBuilderBase
+    {
+        protected void EnsureHistoricalSnapshots(Hire hire, Journey journey, IReadOnlyList<SnapshotSeed> snapshots)
+        {
+            var existingCount = Context.EngagementSnapshots
+                .IgnoreQueryFilters()
+                .Count(snapshot => snapshot.TenantId == Tenant.Id && snapshot.HireId == hire.Id);
+
+            foreach (var snapshotSeed in snapshots.Skip(existingCount))
+            {
+                Context.EngagementSnapshots.Add(new EngagementSnapshot
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id,
+                    HireId = hire.Id,
+                    JourneyId = journey.Id,
+                    CompletionRate = snapshotSeed.CompletionRate,
+                    DaysSinceLastActivity = snapshotSeed.DaysSinceLastActivity,
+                    OverdueTaskCount = snapshotSeed.OverdueTaskCount,
+                    CompositeScore = snapshotSeed.CompositeScore,
+                    Classification = snapshotSeed.Classification,
+                    ComputedAt = snapshotSeed.ComputedAt
+                });
+            }
+
+            Context.SaveChanges();
+        }
+
+        protected void EnsureResolvedFlag(
+            Hire hire,
+            Journey journey,
+            DateTime raisedAt,
+            DateTime acknowledgedAt,
+            DateTime resolvedAt,
+            long acknowledgedByUserId,
+            long resolvedByUserId,
+            string acknowledgementNotes,
+            string resolutionNotes,
+            AtRiskResolutionType resolutionType)
+        {
+            var flag = Context.AtRiskFlags
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingFlag =>
+                    existingFlag.TenantId == Tenant.Id &&
+                    existingFlag.HireId == hire.Id &&
+                    existingFlag.Status == AtRiskFlagStatus.Resolved &&
+                    existingFlag.ResolutionNotes == resolutionNotes);
+
+            if (flag == null)
+            {
+                flag = new AtRiskFlag
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id,
+                    HireId = hire.Id,
+                    JourneyId = journey.Id
+                };
+
+                Context.AtRiskFlags.Add(flag);
+            }
+
+            flag.RaisedAt = raisedAt;
+            flag.ClassificationAtRaise = EngagementClassification.AtRisk;
+            flag.Status = AtRiskFlagStatus.Resolved;
+            flag.AcknowledgedByUserId = acknowledgedByUserId;
+            flag.AcknowledgedAt = acknowledgedAt;
+            flag.AcknowledgementNotes = acknowledgementNotes;
+            flag.ResolvedByUserId = resolvedByUserId;
+            flag.ResolvedAt = resolvedAt;
+            flag.ResolutionType = resolutionType;
+            flag.ResolutionNotes = resolutionNotes;
+            Context.SaveChanges();
+        }
+
+        protected void EnsureActiveFlag(Hire hire, Journey journey, DateTime raisedAt)
+        {
+            var flag = Context.AtRiskFlags
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingFlag =>
+                    existingFlag.TenantId == Tenant.Id &&
+                    existingFlag.HireId == hire.Id &&
+                    existingFlag.Status != AtRiskFlagStatus.Resolved);
+
+            if (flag == null)
+            {
+                flag = new AtRiskFlag
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id,
+                    HireId = hire.Id,
+                    JourneyId = journey.Id
+                };
+
+                Context.AtRiskFlags.Add(flag);
+            }
+
+            flag.RaisedAt = raisedAt;
+            flag.ClassificationAtRaise = EngagementClassification.AtRisk;
+            flag.Status = AtRiskFlagStatus.Active;
+            flag.AcknowledgedByUserId = null;
+            flag.AcknowledgedAt = null;
+            flag.AcknowledgementNotes = null;
+            flag.ResolvedByUserId = null;
+            flag.ResolvedAt = null;
+            flag.ResolutionType = null;
+            flag.ResolutionNotes = null;
+            Context.SaveChanges();
+        }
+
+        /// <summary>
+        /// Represents one pre-seeded historical engagement snapshot.
+        /// </summary>
+        protected sealed record SnapshotSeed(
+            decimal CompletionRate,
+            int DaysSinceLastActivity,
+            int OverdueTaskCount,
+            decimal CompositeScore,
+            EngagementClassification Classification,
+            DateTime ComputedAt);
+    }
+}

--- a/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoTenantDataBuilderBase.cs
+++ b/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoTenantDataBuilderBase.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Abp.Authorization.Users;
+using JourneyPoint.Authorization.Users;
+using JourneyPoint.Domains.Engagement;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+using JourneyPoint.MultiTenancy;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace JourneyPoint.EntityFrameworkCore.Seed.Tenants
+{
+    /// <summary>
+    /// Provides idempotent helpers for tenant-scoped demo data builders.
+    /// </summary>
+    public abstract partial class DemoTenantDataBuilderBase
+    {
+        private readonly PasswordHasher<User> _passwordHasher =
+            new(new OptionsWrapper<PasswordHasherOptions>(new PasswordHasherOptions()));
+
+        /// <summary>
+        /// Initializes the base seed builder for one tenant.
+        /// </summary>
+        protected DemoTenantDataBuilderBase(JourneyPointDbContext context, Tenant tenant)
+        {
+            Context = context;
+            Tenant = tenant;
+        }
+
+        /// <summary>
+        /// Gets the shared database context used for demo seeding.
+        /// </summary>
+        protected JourneyPointDbContext Context { get; }
+
+        /// <summary>
+        /// Gets the tenant currently being seeded.
+        /// </summary>
+        protected Tenant Tenant { get; }
+
+        /// <summary>
+        /// Creates the tenant-specific demo data set.
+        /// </summary>
+        public abstract void Create();
+
+        protected User EnsureUser(string username, string emailAddress, string firstName, string lastName, params string[] roleNames)
+        {
+            var user = Context.Users
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingUser => existingUser.TenantId == Tenant.Id && existingUser.UserName == username);
+
+            if (user == null)
+            {
+                user = new User
+                {
+                    TenantId = Tenant.Id,
+                    UserName = username
+                };
+
+                Context.Users.Add(user);
+            }
+
+            user.Name = firstName;
+            user.Surname = lastName;
+            user.EmailAddress = emailAddress;
+            user.IsEmailConfirmed = true;
+            user.IsActive = true;
+            user.SetNormalizedNames();
+            user.Password = _passwordHasher.HashPassword(user, User.DefaultPassword);
+            Context.SaveChanges();
+
+            foreach (var roleName in roleNames.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                EnsureUserRole(user, roleName);
+            }
+
+            Context.SaveChanges();
+            return user;
+        }
+
+        protected OnboardingPlan EnsurePublishedPlan(string name, string description, string targetAudience, int durationDays)
+        {
+            var plan = Context.OnboardingPlans
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingPlan => existingPlan.TenantId == Tenant.Id && existingPlan.Name == name);
+
+            if (plan == null)
+            {
+                plan = new OnboardingPlan
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id
+                };
+
+                Context.OnboardingPlans.Add(plan);
+            }
+
+            plan.Name = name;
+            plan.Description = description;
+            plan.TargetAudience = targetAudience;
+            plan.DurationDays = durationDays;
+            plan.Status = OnboardingPlanStatus.Published;
+            Context.SaveChanges();
+            return plan;
+        }
+
+        protected OnboardingModule EnsureModule(OnboardingPlan plan, int orderIndex, string name, string description)
+        {
+            var module = Context.OnboardingModules
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingModule =>
+                    existingModule.TenantId == Tenant.Id &&
+                    existingModule.OnboardingPlanId == plan.Id &&
+                    existingModule.OrderIndex == orderIndex);
+
+            if (module == null)
+            {
+                module = new OnboardingModule
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id,
+                    OnboardingPlanId = plan.Id
+                };
+
+                Context.OnboardingModules.Add(module);
+            }
+
+            module.Name = name;
+            module.Description = description;
+            module.OrderIndex = orderIndex;
+            Context.SaveChanges();
+            return module;
+        }
+
+        protected OnboardingTask EnsureTemplateTask(
+            OnboardingModule module,
+            int orderIndex,
+            string title,
+            string description,
+            OnboardingTaskCategory category,
+            int dueDayOffset,
+            OnboardingTaskAssignmentTarget assignmentTarget,
+            OnboardingTaskAcknowledgementRule acknowledgementRule)
+        {
+            var task = Context.OnboardingTasks
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingTask =>
+                    existingTask.TenantId == Tenant.Id &&
+                    existingTask.OnboardingModuleId == module.Id &&
+                    existingTask.OrderIndex == orderIndex);
+
+            if (task == null)
+            {
+                task = new OnboardingTask
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id,
+                    OnboardingModuleId = module.Id
+                };
+
+                Context.OnboardingTasks.Add(task);
+            }
+
+            task.Title = title;
+            task.Description = description;
+            task.Category = category;
+            task.OrderIndex = orderIndex;
+            task.DueDayOffset = dueDayOffset;
+            task.AssignmentTarget = assignmentTarget;
+            task.AcknowledgementRule = acknowledgementRule;
+            Context.SaveChanges();
+            return task;
+        }
+
+        protected Hire EnsureHire(
+            OnboardingPlan plan,
+            User platformUser,
+            User managerUser,
+            string fullName,
+            string emailAddress,
+            string roleTitle,
+            string department,
+            DateTime startDate,
+            HireLifecycleState status,
+            WelcomeNotificationStatus welcomeStatus,
+            DateTime? welcomeLastAttemptedAt,
+            DateTime? welcomeSentAt,
+            string welcomeFailureReason,
+            DateTime? activatedAt,
+            DateTime? completedAt)
+        {
+            var hire = Context.Hires
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingHire => existingHire.TenantId == Tenant.Id && existingHire.EmailAddress == emailAddress);
+
+            if (hire == null)
+            {
+                hire = new Hire
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id
+                };
+
+                Context.Hires.Add(hire);
+            }
+
+            hire.OnboardingPlanId = plan.Id;
+            hire.PlatformUserId = platformUser.Id;
+            hire.ManagerUserId = managerUser?.Id;
+            hire.FullName = fullName;
+            hire.EmailAddress = emailAddress;
+            hire.RoleTitle = roleTitle;
+            hire.Department = department;
+            hire.StartDate = startDate;
+            hire.Status = status;
+            hire.WelcomeNotificationStatus = welcomeStatus;
+            hire.WelcomeNotificationLastAttemptedAt = welcomeLastAttemptedAt;
+            hire.WelcomeNotificationSentAt = welcomeSentAt;
+            hire.WelcomeNotificationFailureReason = welcomeFailureReason;
+            hire.ActivatedAt = activatedAt;
+            hire.CompletedAt = completedAt;
+            hire.ExitedAt = status == HireLifecycleState.Exited ? completedAt : null;
+            Context.SaveChanges();
+            return hire;
+        }
+
+        protected Journey EnsureJourney(Hire hire, OnboardingPlan plan, JourneyStatus status, DateTime? activatedAt, DateTime? completedAt)
+        {
+            var journey = Context.Journeys
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingJourney => existingJourney.TenantId == Tenant.Id && existingJourney.HireId == hire.Id);
+
+            if (journey == null)
+            {
+                journey = new Journey
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id,
+                    HireId = hire.Id
+                };
+
+                Context.Journeys.Add(journey);
+            }
+
+            journey.OnboardingPlanId = plan.Id;
+            journey.Status = status;
+            journey.ActivatedAt = activatedAt;
+            journey.PausedAt = null;
+            journey.CompletedAt = completedAt;
+            Context.SaveChanges();
+            return journey;
+        }
+
+        protected JourneyTask EnsureJourneyTask(
+            Journey journey,
+            DateTime hireStartDate,
+            OnboardingTask sourceTask,
+            OnboardingModule sourceModule,
+            string title,
+            string description,
+            JourneyTaskStatus status,
+            DateTime? acknowledgedAt,
+            DateTime? completedAt,
+            long? completedByUserId,
+            DateTime? personalisedAt)
+        {
+            var journeyTask = Context.JourneyTasks
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingTask =>
+                    existingTask.TenantId == Tenant.Id &&
+                    existingTask.JourneyId == journey.Id &&
+                    existingTask.ModuleOrderIndex == sourceModule.OrderIndex &&
+                    existingTask.TaskOrderIndex == sourceTask.OrderIndex);
+
+            if (journeyTask == null)
+            {
+                journeyTask = new JourneyTask
+                {
+                    Id = Guid.NewGuid(),
+                    TenantId = Tenant.Id,
+                    JourneyId = journey.Id
+                };
+
+                Context.JourneyTasks.Add(journeyTask);
+            }
+
+            journeyTask.SourceOnboardingTaskId = sourceTask.Id;
+            journeyTask.SourceOnboardingModuleId = sourceModule.Id;
+            journeyTask.ModuleTitle = sourceModule.Name;
+            journeyTask.ModuleOrderIndex = sourceModule.OrderIndex;
+            journeyTask.TaskOrderIndex = sourceTask.OrderIndex;
+            journeyTask.Title = title;
+            journeyTask.Description = description;
+            journeyTask.Category = sourceTask.Category;
+            journeyTask.AssignmentTarget = sourceTask.AssignmentTarget;
+            journeyTask.AcknowledgementRule = sourceTask.AcknowledgementRule;
+            journeyTask.DueDayOffset = sourceTask.DueDayOffset;
+            journeyTask.DueOn = hireStartDate.Date.AddDays(sourceTask.DueDayOffset);
+            journeyTask.Status = status;
+            journeyTask.AcknowledgedAt = acknowledgedAt;
+            journeyTask.CompletedAt = completedAt;
+            journeyTask.CompletedByUserId = completedByUserId;
+            journeyTask.PersonalisedAt = personalisedAt;
+            Context.SaveChanges();
+            return journeyTask;
+        }
+
+        private void EnsureUserRole(User user, string roleName)
+        {
+            var role = Context.Roles
+                .IgnoreQueryFilters()
+                .Single(existingRole => existingRole.TenantId == Tenant.Id && existingRole.Name == roleName);
+
+            var hasRole = Context.UserRoles
+                .IgnoreQueryFilters()
+                .Any(userRole =>
+                    userRole.TenantId == Tenant.Id &&
+                    userRole.UserId == user.Id &&
+                    userRole.RoleId == role.Id);
+
+            if (!hasRole)
+            {
+                Context.UserRoles.Add(new UserRole(Tenant.Id, user.Id, role.Id));
+            }
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoTenantSeedOrchestrator.cs
+++ b/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DemoTenantSeedOrchestrator.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using JourneyPoint.MultiTenancy;
+
+namespace JourneyPoint.EntityFrameworkCore.Seed.Tenants
+{
+    /// <summary>
+    /// Seeds and validates the repository-standard JourneyPoint demo tenants.
+    /// </summary>
+    public class DemoTenantSeedOrchestrator
+    {
+        private readonly JourneyPointDbContext _context;
+
+        /// <summary>
+        /// Initializes the demo tenant seed orchestrator.
+        /// </summary>
+        public DemoTenantSeedOrchestrator(JourneyPointDbContext context)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Creates the Boxfusion and DeptDemo demo tenants with their seed data.
+        /// </summary>
+        public void Create()
+        {
+            var boxfusionTenant = EnsureTenant("boxfusion", "Boxfusion");
+            new TenantRoleAndUserBuilder(_context, boxfusionTenant.Id).Create();
+            new BoxfusionDemoDataBuilder(_context, boxfusionTenant).Create();
+
+            var deptDemoTenant = EnsureTenant("deptdemo", "DeptDemo");
+            new TenantRoleAndUserBuilder(_context, deptDemoTenant.Id).Create();
+            new DeptDemoDataBuilder(_context, deptDemoTenant).Create();
+
+            new DemoSeedValidator(_context).Validate();
+        }
+
+        private Tenant EnsureTenant(string tenancyName, string name)
+        {
+            var tenant = _context.Tenants
+                .IgnoreQueryFilters()
+                .SingleOrDefault(existingTenant => existingTenant.TenancyName == tenancyName);
+
+            if (tenant == null)
+            {
+                tenant = new Tenant(tenancyName, name);
+                _context.Tenants.Add(tenant);
+                _context.SaveChanges();
+                return tenant;
+            }
+
+            tenant.Name = name;
+            _context.SaveChanges();
+            return tenant;
+        }
+    }
+}

--- a/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DeptDemoDataBuilder.cs
+++ b/aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/DeptDemoDataBuilder.cs
@@ -1,0 +1,93 @@
+using System;
+using JourneyPoint.Authorization.Roles;
+using JourneyPoint.Authorization.Users;
+using JourneyPoint.Domains.Engagement;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+using JourneyPoint.MultiTenancy;
+
+namespace JourneyPoint.EntityFrameworkCore.Seed.Tenants
+{
+    /// <summary>
+    /// Seeds the DeptDemo tenant with stage-varied demo journeys for milestone validation.
+    /// </summary>
+    public class DeptDemoDataBuilder : DemoTenantDataBuilderBase
+    {
+        /// <summary>
+        /// Initializes the DeptDemo demo-data builder.
+        /// </summary>
+        public DeptDemoDataBuilder(JourneyPointDbContext context, Tenant tenant)
+            : base(context, tenant)
+        {
+        }
+
+        /// <summary>
+        /// Creates the DeptDemo facilitator, manager, hire, and journey demo state.
+        /// </summary>
+        public override void Create()
+        {
+            var manager = EnsureUser("manager.deptdemo", "manager@deptdemo.demo", "Amos", "Mathebula", StaticRoleNames.Tenants.Manager);
+            EnsureUser("facilitator.deptdemo", "facilitator@deptdemo.demo", "Naledi", "Peters", StaticRoleNames.Tenants.Facilitator);
+            var ayandaUser = EnsureUser("ayanda.deptdemo", "ayanda@deptdemo.demo", "Ayanda", "Govender", StaticRoleNames.Tenants.Enrolee);
+            var musaUser = EnsureUser("musa.deptdemo", "musa@deptdemo.demo", "Musa", "Dlamini", StaticRoleNames.Tenants.Enrolee);
+
+            var plan = EnsurePublishedPlan(
+                "DeptDemo Public Service Onboarding",
+                "A reusable public-service onboarding pathway for citizen-facing programme teams.",
+                "Public-sector programme hires",
+                18);
+
+            var complianceModule = EnsureModule(plan, 1, "Service Foundations", "Orient the hire to public-service standards and mandatory reading.");
+            var deliveryModule = EnsureModule(plan, 2, "Citizen Delivery Practice", "Build hands-on service-delivery capability and guided shadowing.");
+            var readinessModule = EnsureModule(plan, 3, "Readiness Sign-off", "Confirm readiness with manager and programme sign-off.");
+
+            var securityBriefing = EnsureTemplateTask(complianceModule, 1, "Attend security briefing", "Join the mandatory information-security induction for the department.", OnboardingTaskCategory.Orientation, 0, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.NotRequired);
+            var ethicsPolicy = EnsureTemplateTask(complianceModule, 2, "Acknowledge ethics policy", "Read and acknowledge the ethics and citizen-service policy pack.", OnboardingTaskCategory.Learning, 1, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.Required);
+            var officeSetup = EnsureTemplateTask(deliveryModule, 1, "Manager office setup review", "Manager confirms workstation, tools, and access readiness.", OnboardingTaskCategory.CheckIn, 3, OnboardingTaskAssignmentTarget.Manager, OnboardingTaskAcknowledgementRule.NotRequired);
+            var serviceShadowing = EnsureTemplateTask(deliveryModule, 2, "Shadow service desk workflow", "Observe a live citizen-service workflow and capture follow-up questions.", OnboardingTaskCategory.Practice, 5, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.NotRequired);
+            var knowledgeCheck = EnsureTemplateTask(readinessModule, 1, "Complete knowledge check", "Finish the public-service readiness knowledge check.", OnboardingTaskCategory.Assessment, 7, OnboardingTaskAssignmentTarget.Enrolee, OnboardingTaskAcknowledgementRule.NotRequired);
+            var readinessSignOff = EnsureTemplateTask(readinessModule, 2, "Manager readiness sign-off", "Manager signs off final onboarding readiness.", OnboardingTaskCategory.CheckIn, 10, OnboardingTaskAssignmentTarget.Manager, OnboardingTaskAcknowledgementRule.NotRequired);
+
+            SeedDraftHire(plan, manager, ayandaUser, complianceModule, deliveryModule, readinessModule, securityBriefing, ethicsPolicy, officeSetup, serviceShadowing, knowledgeCheck, readinessSignOff);
+            SeedCompletedHire(plan, manager, musaUser, complianceModule, deliveryModule, readinessModule, securityBriefing, ethicsPolicy, officeSetup, serviceShadowing, knowledgeCheck, readinessSignOff);
+        }
+
+        private void SeedDraftHire(OnboardingPlan plan, User manager, User enrolee, OnboardingModule complianceModule, OnboardingModule deliveryModule, OnboardingModule readinessModule, OnboardingTask securityBriefing, OnboardingTask ethicsPolicy, OnboardingTask officeSetup, OnboardingTask serviceShadowing, OnboardingTask knowledgeCheck, OnboardingTask readinessSignOff)
+        {
+            var today = DateTime.UtcNow.Date;
+            var startDate = today.AddDays(3);
+            var hire = EnsureHire(plan, enrolee, manager, "Ayanda Govender", enrolee.EmailAddress, "Citizen Services Officer", "Field Operations", startDate, HireLifecycleState.PendingActivation, WelcomeNotificationStatus.FailedRecoverable, today.AddDays(-1), null, "SMTP demo relay unavailable during the initial welcome attempt.", null, null);
+            var journey = EnsureJourney(hire, plan, JourneyStatus.Draft, null, null);
+
+            EnsureJourneyTask(journey, startDate, securityBriefing, complianceModule, securityBriefing.Title, securityBriefing.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, ethicsPolicy, complianceModule, ethicsPolicy.Title, ethicsPolicy.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, officeSetup, deliveryModule, officeSetup.Title, officeSetup.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, serviceShadowing, deliveryModule, serviceShadowing.Title, serviceShadowing.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, knowledgeCheck, readinessModule, knowledgeCheck.Title, knowledgeCheck.Description, JourneyTaskStatus.Pending, null, null, null, null);
+            EnsureJourneyTask(journey, startDate, readinessSignOff, readinessModule, readinessSignOff.Title, readinessSignOff.Description, JourneyTaskStatus.Pending, null, null, null, null);
+        }
+
+        private void SeedCompletedHire(OnboardingPlan plan, User manager, User enrolee, OnboardingModule complianceModule, OnboardingModule deliveryModule, OnboardingModule readinessModule, OnboardingTask securityBriefing, OnboardingTask ethicsPolicy, OnboardingTask officeSetup, OnboardingTask serviceShadowing, OnboardingTask knowledgeCheck, OnboardingTask readinessSignOff)
+        {
+            var today = DateTime.UtcNow.Date;
+            var startDate = today.AddDays(-16);
+            var completedAt = today.AddDays(-2);
+            var hire = EnsureHire(plan, enrolee, manager, "Musa Dlamini", enrolee.EmailAddress, "Programme Support Officer", "Citizen Experience", startDate, HireLifecycleState.Completed, WelcomeNotificationStatus.Sent, startDate, startDate, null, startDate, completedAt);
+            var journey = EnsureJourney(hire, plan, JourneyStatus.Completed, startDate, completedAt);
+
+            EnsureJourneyTask(journey, startDate, securityBriefing, complianceModule, securityBriefing.Title, securityBriefing.Description, JourneyTaskStatus.Completed, null, startDate, enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, ethicsPolicy, complianceModule, ethicsPolicy.Title, ethicsPolicy.Description, JourneyTaskStatus.Completed, startDate.AddDays(1), startDate.AddDays(1), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, officeSetup, deliveryModule, officeSetup.Title, officeSetup.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(3), manager.Id, null);
+            EnsureJourneyTask(journey, startDate, serviceShadowing, deliveryModule, serviceShadowing.Title, serviceShadowing.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(5), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, knowledgeCheck, readinessModule, knowledgeCheck.Title, knowledgeCheck.Description, JourneyTaskStatus.Completed, null, startDate.AddDays(7), enrolee.Id, null);
+            EnsureJourneyTask(journey, startDate, readinessSignOff, readinessModule, readinessSignOff.Title, readinessSignOff.Description, JourneyTaskStatus.Completed, null, completedAt, manager.Id, null);
+
+            EnsureHistoricalSnapshots(hire, journey, new[]
+            {
+                new SnapshotSeed(33.33m, 3, 1, 51.66m, EngagementClassification.NeedsAttention, today.AddDays(-12).AddHours(14)),
+                new SnapshotSeed(66.67m, 1, 0, 83.34m, EngagementClassification.Healthy, today.AddDays(-8).AddHours(14)),
+                new SnapshotSeed(100m, 1, 0, 100m, EngagementClassification.Healthy, today.AddDays(-3).AddHours(14))
+            });
+        }
+    }
+}

--- a/specs/001-journeypoint-platform/quickstart.md
+++ b/specs/001-journeypoint-platform/quickstart.md
@@ -21,6 +21,7 @@ Expected result:
 - database migrations apply successfully
 - ABP API starts
 - Swagger is available
+- host, default, Boxfusion, and DeptDemo seed data is available after the migrator completes
 
 ## Frontend Setup
 
@@ -179,3 +180,42 @@ Expected result:
 - DeptDemo tenant contains a government onboarding programme with at least two
   hires at different journey stages.
 - Four roles exist: TenantAdmin, Facilitator, Manager, Enrolee.
+
+## Demo Login Matrix
+
+All demo users use password `123qwe`.
+
+### Boxfusion
+
+- Tenant: `boxfusion`
+- Tenant admin: username `admin`
+- Facilitator: username `facilitator.boxfusion`
+- Manager: username `manager.boxfusion`
+- Enrolees:
+  - `alex.boxfusion`
+  - `nomsa.boxfusion`
+  - `thabo.boxfusion`
+
+### DeptDemo
+
+- Tenant: `deptdemo`
+- Tenant admin: username `admin`
+- Facilitator: username `facilitator.deptdemo`
+- Manager: username `manager.deptdemo`
+- Enrolees:
+  - `ayanda.deptdemo`
+  - `musa.deptdemo`
+
+## Demo Walkthrough Notes
+
+- Use Boxfusion for the full active-product loop: hire detail, manager tasks,
+  enrolee journey participation, pipeline, score history, and intervention
+  views.
+- Use DeptDemo to demonstrate journey-stage variation:
+  - `Ayanda Govender` starts in `PendingActivation` with a `Draft` journey and
+    a recoverable welcome-notification failure.
+  - `Musa Dlamini` starts in the completed column with completed-journey
+    history.
+- The Boxfusion cohort is intentionally seeded so the next live pipeline or
+  hire-intelligence load recomputes into one `Healthy`, one `NeedsAttention`,
+  and one `AtRisk` hire without manual data patching.

--- a/specs/001-journeypoint-platform/tasks.md
+++ b/specs/001-journeypoint-platform/tasks.md
@@ -196,7 +196,7 @@ engagement data, surfaces at-risk hires, and supports facilitator intervention.
 - [x] T049 [P] [US5] Build facilitator pipeline page in `journeypoint/app/(facilitator)/pipeline/page.tsx`
 - [x] T050 [P] [US5] Add engagement and pipeline provider state in `journeypoint/providers/engagementProvider/` and `journeypoint/providers/pipelineProvider/`
 - [x] T051 [P] [US5] Build intelligence components in `journeypoint/components/pipeline/PipelineKanban.tsx`, `PipelineColumn.tsx`, `HirePipelineCard.tsx`, `journeypoint/components/engagement/EngagementBadge.tsx`, `AtRiskFlagPanel.tsx`, and `journeypoint/components/journey/ScoreTrendChart.tsx`
-- [ ] T052 [US5] Seed Boxfusion and DeptDemo demo data in `aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/`
+- [x] T052 [US5] Seed Boxfusion and DeptDemo demo data in `aspnet-core/src/JourneyPoint.EntityFrameworkCore/EntityFrameworkCore/Seed/`
 - [x] T053 [US5] Add facilitator intervention capture and flag history UI in `journeypoint/app/(facilitator)/hires/[hireId]/page.tsx`
 
 **Checkpoint**: Intelligence, flags, pipeline, and intervention flows are demonstrable.


### PR DESCRIPTION
Linking Issues: #42 

- Added DemoSeedValidator to ensure demo tenant data meets engagement expectations.
- Created DemoTenantDataBuilderBase with methods for managing tenant-specific demo data.
- Introduced DeptDemoDataBuilder for seeding the DeptDemo tenant with onboarding journeys.
- Developed DemoTenantSeedOrchestrator to manage the creation of demo tenants and their data.
- Seeded Boxfusion and DeptDemo demo data, including various hire stages and engagement snapshots.
- Updated quickstart and tasks documentation to reflect new demo data and user roles.