### PR TITLE
Add extensive backend unit and integration tests

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "journeypoint-frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    },
+    {
+      "name": "journeypoint-api",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "aspnet-core/src/JourneyPoint.Web.Host/JourneyPoint.Web.Host.csproj"],
+      "port": 44311
+    },
+    {
+      "name": "journeypoint-migrator",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "aspnet-core/src/JourneyPoint.Migrator/JourneyPoint.Migrator.csproj"],
+      "port": 0
+    }
+  ]
+}

--- a/aspnet-core/test/JourneyPoint.Tests/Domains/EngagementManager_Tests.cs
+++ b/aspnet-core/test/JourneyPoint.Tests/Domains/EngagementManager_Tests.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.ObjectModel;
+using JourneyPoint.Domains.Engagement;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+using Shouldly;
+using Xunit;
+
+namespace JourneyPoint.Tests.Domains
+{
+    public class EngagementManager_Tests
+    {
+        private readonly EngagementManager _manager = new();
+
+        // ─── Helpers ───────────────────────────────────────────────────────────────
+
+        private static Hire MakeHire(int tenantId = 1)
+        {
+            var planId = Guid.NewGuid();
+            return new Hire
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                OnboardingPlanId = planId,
+                FullName = "Test Hire",
+                EmailAddress = "hire@example.com",
+                StartDate = DateTime.Today,
+                Status = HireLifecycleState.Active,
+                WelcomeNotificationStatus = WelcomeNotificationStatus.Sent
+            };
+        }
+
+        private static Journey MakeJourneyFor(Hire hire)
+        {
+            var journey = new Journey
+            {
+                Id = Guid.NewGuid(),
+                TenantId = hire.TenantId,
+                HireId = hire.Id,
+                OnboardingPlanId = hire.OnboardingPlanId,
+                Status = JourneyStatus.Active,
+                Tasks = new Collection<JourneyTask>()
+            };
+            hire.Journey = journey;
+            return journey;
+        }
+
+        private static EngagementScoreInput MakeInput() =>
+            new()
+            {
+                TotalTaskCount = 10,
+                CompletedTaskCount = 5,
+                DaysSinceLastActivity = 2,
+                OverdueTaskCount = 0,
+                ComputedAt = DateTime.UtcNow
+            };
+
+        private static EngagementScoreResult MakeResult(EngagementClassification classification = EngagementClassification.Healthy) =>
+            new()
+            {
+                CompletionRate = 50m,
+                CompletionScore = 50m,
+                RecencyScore = 100m,
+                OverdueScore = 100m,
+                CompositeScore = 75m,
+                Classification = classification,
+                ComputedAt = DateTime.UtcNow
+            };
+
+        private static AtRiskFlag ActiveFlagFor(Hire hire, Journey journey) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                TenantId = hire.TenantId,
+                HireId = hire.Id,
+                JourneyId = journey.Id,
+                RaisedAt = DateTime.UtcNow.AddDays(-1),
+                ClassificationAtRaise = EngagementClassification.AtRisk,
+                Status = AtRiskFlagStatus.Active
+            };
+
+        // ─── CreateSnapshot ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void CreateSnapshot_WithValidInputs_ReturnsSnapshotWithExpectedValues()
+        {
+            var hire = MakeHire();
+            var journey = MakeJourneyFor(hire);
+            var input = MakeInput();
+            var result = MakeResult();
+
+            var snapshot = _manager.CreateSnapshot(1, hire, journey, input, result);
+
+            snapshot.ShouldNotBeNull();
+            snapshot.TenantId.ShouldBe(1);
+            snapshot.HireId.ShouldBe(hire.Id);
+            snapshot.JourneyId.ShouldBe(journey.Id);
+            snapshot.CompositeScore.ShouldBe(result.CompositeScore);
+            snapshot.Classification.ShouldBe(result.Classification);
+        }
+
+        [Fact]
+        public void CreateSnapshot_WithNullHire_ThrowsArgumentNullException()
+        {
+            var journey = MakeJourneyFor(MakeHire());
+
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.CreateSnapshot(1, null, journey, MakeInput(), MakeResult()));
+        }
+
+        [Fact]
+        public void CreateSnapshot_WithNullJourney_ThrowsArgumentNullException()
+        {
+            var hire = MakeHire();
+
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.CreateSnapshot(1, hire, null, MakeInput(), MakeResult()));
+        }
+
+        [Fact]
+        public void CreateSnapshot_WithNullInput_ThrowsArgumentNullException()
+        {
+            var hire = MakeHire();
+            var journey = MakeJourneyFor(hire);
+
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.CreateSnapshot(1, hire, journey, null, MakeResult()));
+        }
+
+        [Fact]
+        public void CreateSnapshot_WithNullResult_ThrowsArgumentNullException()
+        {
+            var hire = MakeHire();
+            var journey = MakeJourneyFor(hire);
+
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.CreateSnapshot(1, hire, journey, MakeInput(), null));
+        }
+
+        [Fact]
+        public void CreateSnapshot_WithMismatchedTenant_ThrowsInvalidOperationException()
+        {
+            var hire = MakeHire(tenantId: 1);
+            var journey = MakeJourneyFor(hire);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.CreateSnapshot(99, hire, journey, MakeInput(), MakeResult()));
+        }
+
+        [Fact]
+        public void CreateSnapshot_WithZeroTenantId_ThrowsArgumentOutOfRangeException()
+        {
+            var hire = MakeHire(tenantId: 1);
+            var journey = MakeJourneyFor(hire);
+
+            Should.Throw<ArgumentOutOfRangeException>(() =>
+                _manager.CreateSnapshot(0, hire, journey, MakeInput(), MakeResult()));
+        }
+
+        // ─── RaiseAtRiskFlag ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void RaiseAtRiskFlag_WithAtRiskClassification_ReturnsFlagInActiveStatus()
+        {
+            var hire = MakeHire();
+            var journey = MakeJourneyFor(hire);
+            var raisedAt = DateTime.UtcNow;
+
+            var flag = _manager.RaiseAtRiskFlag(1, hire, journey, EngagementClassification.AtRisk, raisedAt);
+
+            flag.ShouldNotBeNull();
+            flag.Status.ShouldBe(AtRiskFlagStatus.Active);
+            flag.ClassificationAtRaise.ShouldBe(EngagementClassification.AtRisk);
+            flag.HireId.ShouldBe(hire.Id);
+            flag.JourneyId.ShouldBe(journey.Id);
+        }
+
+        [Fact]
+        public void RaiseAtRiskFlag_WithHealthyClassification_ThrowsInvalidOperationException()
+        {
+            var hire = MakeHire();
+            var journey = MakeJourneyFor(hire);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.RaiseAtRiskFlag(1, hire, journey, EngagementClassification.Healthy, DateTime.UtcNow));
+        }
+
+        [Fact]
+        public void RaiseAtRiskFlag_WithNeedsAttentionClassification_ThrowsInvalidOperationException()
+        {
+            var hire = MakeHire();
+            var journey = MakeJourneyFor(hire);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.RaiseAtRiskFlag(1, hire, journey, EngagementClassification.NeedsAttention, DateTime.UtcNow));
+        }
+
+        // ─── AcknowledgeFlag ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void AcknowledgeFlag_ActiveFlag_TransitionsToAcknowledged()
+        {
+            var hire = MakeHire();
+            var journey = MakeJourneyFor(hire);
+            var flag = ActiveFlagFor(hire, journey);
+
+            _manager.AcknowledgeFlag(flag, 1L, "Noted — will follow up");
+
+            flag.Status.ShouldBe(AtRiskFlagStatus.Acknowledged);
+            flag.AcknowledgedByUserId.ShouldBe(1L);
+            flag.AcknowledgedAt.ShouldNotBeNull();
+            flag.AcknowledgementNotes.ShouldBe("Noted — will follow up");
+        }
+
+        [Fact]
+        public void AcknowledgeFlag_WithTrimmedNotes_StoresNormalisedNotes()
+        {
+            var hire = MakeHire();
+            var flag = ActiveFlagFor(hire, MakeJourneyFor(hire));
+
+            _manager.AcknowledgeFlag(flag, 1L, "  note  ");
+
+            flag.AcknowledgementNotes.ShouldBe("note");
+        }
+
+        [Fact]
+        public void AcknowledgeFlag_AlreadyResolvedFlag_ThrowsInvalidOperationException()
+        {
+            var hire = MakeHire();
+            var flag = ActiveFlagFor(hire, MakeJourneyFor(hire));
+            flag.Status = AtRiskFlagStatus.Resolved;
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.AcknowledgeFlag(flag, 1L, null));
+        }
+
+        [Fact]
+        public void AcknowledgeFlag_WithNullFlag_ThrowsArgumentNullException()
+        {
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.AcknowledgeFlag(null, 1L, null));
+        }
+
+        // ─── ResolveFlag ───────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ResolveFlag_ActiveFlag_TransitionsToResolved()
+        {
+            var hire = MakeHire();
+            var flag = ActiveFlagFor(hire, MakeJourneyFor(hire));
+
+            _manager.ResolveFlag(flag, 2L, AtRiskResolutionType.ManualFacilitatorResolution, "Resolved after check-in");
+
+            flag.Status.ShouldBe(AtRiskFlagStatus.Resolved);
+            flag.ResolvedByUserId.ShouldBe(2L);
+            flag.ResolvedAt.ShouldNotBeNull();
+            flag.ResolutionType.ShouldBe(AtRiskResolutionType.ManualFacilitatorResolution);
+        }
+
+        [Fact]
+        public void ResolveFlag_AcknowledgedFlag_TransitionsToResolved()
+        {
+            var hire = MakeHire();
+            var flag = ActiveFlagFor(hire, MakeJourneyFor(hire));
+            flag.Status = AtRiskFlagStatus.Acknowledged;
+
+            _manager.ResolveFlag(flag, 2L, AtRiskResolutionType.ManualFacilitatorResolution, null);
+
+            flag.Status.ShouldBe(AtRiskFlagStatus.Resolved);
+        }
+
+        [Fact]
+        public void ResolveFlag_AlreadyResolvedFlag_ThrowsInvalidOperationException()
+        {
+            var hire = MakeHire();
+            var flag = ActiveFlagFor(hire, MakeJourneyFor(hire));
+            flag.Status = AtRiskFlagStatus.Resolved;
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.ResolveFlag(flag, 2L, AtRiskResolutionType.ManualFacilitatorResolution, null));
+        }
+
+        // ─── AutoResolveFlag ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void AutoResolveFlag_ActiveFlag_SetsAutomaticHealthyRecoveryType()
+        {
+            var hire = MakeHire();
+            var flag = ActiveFlagFor(hire, MakeJourneyFor(hire));
+
+            _manager.AutoResolveFlag(flag);
+
+            flag.Status.ShouldBe(AtRiskFlagStatus.Resolved);
+            flag.ResolutionType.ShouldBe(AtRiskResolutionType.AutomaticHealthyRecovery);
+            flag.ResolvedByUserId.ShouldBeNull();
+            flag.ResolutionNotes.ShouldBeNull();
+        }
+
+        [Fact]
+        public void AutoResolveFlag_AlreadyResolvedFlag_ThrowsInvalidOperationException()
+        {
+            var hire = MakeHire();
+            var flag = ActiveFlagFor(hire, MakeJourneyFor(hire));
+            flag.Status = AtRiskFlagStatus.Resolved;
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.AutoResolveFlag(flag));
+        }
+    }
+}

--- a/aspnet-core/test/JourneyPoint.Tests/Domains/EngagementScoreService_Tests.cs
+++ b/aspnet-core/test/JourneyPoint.Tests/Domains/EngagementScoreService_Tests.cs
@@ -1,0 +1,278 @@
+using System;
+using JourneyPoint.Domains.Engagement;
+using Shouldly;
+using Xunit;
+
+namespace JourneyPoint.Tests.Domains
+{
+    public class EngagementScoreService_Tests
+    {
+        private readonly EngagementScoreService _service = new();
+
+        private static EngagementScoreInput ValidInput(
+            int total = 10,
+            int completed = 5,
+            int daysSince = 0,
+            int overdue = 0) =>
+            new()
+            {
+                TotalTaskCount = total,
+                CompletedTaskCount = completed,
+                DaysSinceLastActivity = daysSince,
+                OverdueTaskCount = overdue,
+                ComputedAt = DateTime.UtcNow
+            };
+
+        // ─── Validation ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_WithNullInput_ThrowsArgumentNullException()
+        {
+            Should.Throw<ArgumentNullException>(() => _service.Calculate(null));
+        }
+
+        [Fact]
+        public void Calculate_WithZeroTotalTaskCount_ThrowsArgumentOutOfRangeException()
+        {
+            var input = ValidInput(total: 0, completed: 0);
+
+            Should.Throw<ArgumentOutOfRangeException>(() => _service.Calculate(input));
+        }
+
+        [Fact]
+        public void Calculate_WithNegativeCompletedCount_ThrowsArgumentOutOfRangeException()
+        {
+            var input = ValidInput(total: 10, completed: -1);
+
+            Should.Throw<ArgumentOutOfRangeException>(() => _service.Calculate(input));
+        }
+
+        [Fact]
+        public void Calculate_WithCompletedExceedingTotal_ThrowsArgumentOutOfRangeException()
+        {
+            var input = ValidInput(total: 5, completed: 10);
+
+            Should.Throw<ArgumentOutOfRangeException>(() => _service.Calculate(input));
+        }
+
+        [Fact]
+        public void Calculate_WithNegativeDaysSinceLastActivity_ThrowsArgumentOutOfRangeException()
+        {
+            var input = ValidInput();
+            input.DaysSinceLastActivity = -1;
+
+            Should.Throw<ArgumentOutOfRangeException>(() => _service.Calculate(input));
+        }
+
+        [Fact]
+        public void Calculate_WithNegativeOverdueTaskCount_ThrowsArgumentOutOfRangeException()
+        {
+            var input = ValidInput();
+            input.OverdueTaskCount = -1;
+
+            Should.Throw<ArgumentOutOfRangeException>(() => _service.Calculate(input));
+        }
+
+        [Fact]
+        public void Calculate_WithDefaultComputedAt_ThrowsArgumentOutOfRangeException()
+        {
+            var input = ValidInput();
+            input.ComputedAt = default;
+
+            Should.Throw<ArgumentOutOfRangeException>(() => _service.Calculate(input));
+        }
+
+        // ─── Completion rate ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_WithFullCompletion_SetsCompletionRateTo100()
+        {
+            var input = ValidInput(total: 10, completed: 10, daysSince: 0, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.CompletionRate.ShouldBe(100m);
+        }
+
+        [Fact]
+        public void Calculate_WithZeroCompletion_SetsCompletionRateTo0()
+        {
+            var input = ValidInput(total: 10, completed: 0, daysSince: 0, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.CompletionRate.ShouldBe(0m);
+        }
+
+        [Fact]
+        public void Calculate_WithHalfCompletion_SetsCompletionRateTo50()
+        {
+            var input = ValidInput(total: 10, completed: 5, daysSince: 0, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.CompletionRate.ShouldBe(50m);
+        }
+
+        // ─── Recency score ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_WithZeroDaysSinceActivity_SetsRecencyScoreTo100()
+        {
+            var input = ValidInput(daysSince: 0);
+
+            var result = _service.Calculate(input);
+
+            result.RecencyScore.ShouldBe(100m);
+        }
+
+        [Fact]
+        public void Calculate_WithActivityAtThreshold_SetsRecencyScoreToZero()
+        {
+            // RecencyZeroScoreDay = 14
+            var input = ValidInput(daysSince: EngagementScoreService.RecencyZeroScoreDay);
+
+            var result = _service.Calculate(input);
+
+            result.RecencyScore.ShouldBe(0m);
+        }
+
+        [Fact]
+        public void Calculate_WithActivityBeyondThreshold_SetsRecencyScoreToZero()
+        {
+            var input = ValidInput(daysSince: 30);
+
+            var result = _service.Calculate(input);
+
+            result.RecencyScore.ShouldBe(0m);
+        }
+
+        [Fact]
+        public void Calculate_WithSevenDaysSinceActivity_SetsRecencyScoreToFiftyPercent()
+        {
+            // 7 days = 7/14 * 100 = 50
+            var input = ValidInput(daysSince: 7);
+
+            var result = _service.Calculate(input);
+
+            result.RecencyScore.ShouldBe(50m);
+        }
+
+        // ─── Overdue penalty ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_WithNoOverdueTasks_SetsOverdueScoreTo100()
+        {
+            var input = ValidInput(overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.OverdueScore.ShouldBe(100m);
+        }
+
+        [Fact]
+        public void Calculate_WithOneOverdueTask_ReducesOverdueScoreBy25()
+        {
+            var input = ValidInput(overdue: 1);
+
+            var result = _service.Calculate(input);
+
+            result.OverdueScore.ShouldBe(75m);
+        }
+
+        [Fact]
+        public void Calculate_WithFourOrMoreOverdueTasks_ClampsOverdueScoreToZero()
+        {
+            var input = ValidInput(overdue: 5);
+
+            var result = _service.Calculate(input);
+
+            result.OverdueScore.ShouldBe(0m);
+        }
+
+        // ─── Composite score ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_KnownInputs_ProducesExpectedCompositeScore()
+        {
+            // completion=50, recency=100, overdue=100
+            // composite = 50*0.5 + 100*0.3 + 100*0.2 = 25 + 30 + 20 = 75
+            var input = ValidInput(total: 10, completed: 5, daysSince: 0, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.CompositeScore.ShouldBe(75m);
+        }
+
+        [Fact]
+        public void Calculate_PerfectInputs_ProducesScoreOf100()
+        {
+            var input = ValidInput(total: 10, completed: 10, daysSince: 0, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.CompositeScore.ShouldBe(100m);
+        }
+
+        [Fact]
+        public void Calculate_WorstCaseInputs_ProducesScoreOf0()
+        {
+            // completion=0, recency=0 (14+ days), overdue=0 (clamped) => 0
+            var input = ValidInput(total: 10, completed: 0, daysSince: 14, overdue: 5);
+
+            var result = _service.Calculate(input);
+
+            result.CompositeScore.ShouldBe(0m);
+        }
+
+        // ─── Classification ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_WithScoreAtOrAbove75_ClassifiesAsHealthy()
+        {
+            // 10/10 complete, fresh, no overdue → 100 → Healthy
+            var input = ValidInput(total: 10, completed: 10, daysSince: 0, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.Classification.ShouldBe(EngagementClassification.Healthy);
+        }
+
+        [Fact]
+        public void Calculate_WithScoreBetween50And75_ClassifiesAsNeedsAttention()
+        {
+            // completion=50, recency=100, overdue=100 → composite=75 → Healthy (boundary)
+            // Use completion=40 → 40*0.5 + 100*0.3 + 100*0.2 = 20+30+20 = 70 → NeedsAttention
+            var input = ValidInput(total: 10, completed: 4, daysSince: 0, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.Classification.ShouldBe(EngagementClassification.NeedsAttention);
+        }
+
+        [Fact]
+        public void Calculate_WithScoreBelow50_ClassifiesAsAtRisk()
+        {
+            // completion=0, recency=0, overdue=100 → composite=0*0.5+0*0.3+100*0.2 = 20 → AtRisk
+            var input = ValidInput(total: 10, completed: 0, daysSince: 14, overdue: 0);
+
+            var result = _service.Calculate(input);
+
+            result.Classification.ShouldBe(EngagementClassification.AtRisk);
+        }
+
+        // ─── Result metadata ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_PreservesComputedAtTimestamp()
+        {
+            var timestamp = new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+            var input = ValidInput();
+            input.ComputedAt = timestamp;
+
+            var result = _service.Calculate(input);
+
+            result.ComputedAt.ShouldBe(timestamp);
+        }
+    }
+}

--- a/aspnet-core/test/JourneyPoint.Tests/Domains/HireJourneyManager_Tests.cs
+++ b/aspnet-core/test/JourneyPoint.Tests/Domains/HireJourneyManager_Tests.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.ObjectModel;
+using JourneyPoint.Domains.Hires;
+using JourneyPoint.Domains.OnboardingPlans;
+using Shouldly;
+using Xunit;
+
+namespace JourneyPoint.Tests.Domains
+{
+    public class HireJourneyManager_Tests
+    {
+        private readonly HireJourneyManager _manager = new();
+
+        // ─── Helpers ───────────────────────────────────────────────────────────────
+
+        private static OnboardingPlan PublishedPlan(int tenantId = 1, Guid? id = null) =>
+            new()
+            {
+                Id = id ?? Guid.NewGuid(),
+                TenantId = tenantId,
+                Name = "Graduate Onboarding",
+                Description = "30-day plan",
+                TargetAudience = "Engineers",
+                DurationDays = 30,
+                Status = OnboardingPlanStatus.Published,
+                Modules = new Collection<OnboardingModule>(),
+                Documents = new Collection<OnboardingDocument>()
+            };
+
+        private static Hire SeedHire(int tenantId = 1, Guid? planId = null, HireLifecycleState status = HireLifecycleState.PendingActivation)
+        {
+            var plan = PublishedPlan(tenantId, planId);
+            return new Hire
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                OnboardingPlanId = plan.Id,
+                FullName = "Jane Smith",
+                EmailAddress = "jane@example.com",
+                StartDate = DateTime.Today,
+                Status = status,
+                WelcomeNotificationStatus = WelcomeNotificationStatus.Pending
+            };
+        }
+
+        private static Journey DraftJourneyFor(Hire hire)
+        {
+            var journey = new Journey
+            {
+                Id = Guid.NewGuid(),
+                TenantId = hire.TenantId,
+                HireId = hire.Id,
+                OnboardingPlanId = hire.OnboardingPlanId,
+                Status = JourneyStatus.Draft
+            };
+            hire.Journey = journey;
+            return journey;
+        }
+
+        private static JourneyTask SeedJourneyTask(Journey journey, int moduleOrder = 1, int taskOrder = 1) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                TenantId = journey.TenantId,
+                JourneyId = journey.Id,
+                ModuleTitle = "Week 1",
+                ModuleOrderIndex = moduleOrder,
+                TaskOrderIndex = taskOrder,
+                Title = "Complete paperwork",
+                Description = "Fill in HR forms",
+                Category = OnboardingTaskCategory.Orientation,
+                AssignmentTarget = OnboardingTaskAssignmentTarget.Enrolee,
+                AcknowledgementRule = OnboardingTaskAcknowledgementRule.Required,
+                DueDayOffset = 1,
+                DueOn = DateTime.Today.AddDays(1),
+                Status = JourneyTaskStatus.Pending
+            };
+
+        // ─── CreateHire ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void CreateHire_WithValidInputs_ReturnsHireInPendingActivationState()
+        {
+            var plan = PublishedPlan();
+            var start = DateTime.Today.AddDays(7);
+
+            var hire = _manager.CreateHire(1, plan, "Alice Brown", "alice@example.com", "Developer", "Engineering", start, null);
+
+            hire.ShouldNotBeNull();
+            hire.FullName.ShouldBe("Alice Brown");
+            hire.EmailAddress.ShouldBe("alice@example.com");
+            hire.TenantId.ShouldBe(1);
+            hire.OnboardingPlanId.ShouldBe(plan.Id);
+            hire.Status.ShouldBe(HireLifecycleState.PendingActivation);
+            hire.WelcomeNotificationStatus.ShouldBe(WelcomeNotificationStatus.Pending);
+        }
+
+        [Fact]
+        public void CreateHire_NormalizesEmailToLowercase()
+        {
+            var plan = PublishedPlan();
+
+            var hire = _manager.CreateHire(1, plan, "Bob", "BOB@EXAMPLE.COM", null, null, DateTime.Today, null);
+
+            hire.EmailAddress.ShouldBe("bob@example.com");
+        }
+
+        [Fact]
+        public void CreateHire_TrimsWhitespaceFromFullName()
+        {
+            var plan = PublishedPlan();
+
+            var hire = _manager.CreateHire(1, plan, "  Carol  ", "carol@example.com", null, null, DateTime.Today, null);
+
+            hire.FullName.ShouldBe("Carol");
+        }
+
+        [Fact]
+        public void CreateHire_WithDraftPlan_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+            plan.Status = OnboardingPlanStatus.Draft;
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.CreateHire(1, plan, "Dan", "dan@example.com", null, null, DateTime.Today, null));
+        }
+
+        [Fact]
+        public void CreateHire_WithArchivedPlan_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+            plan.Status = OnboardingPlanStatus.Archived;
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.CreateHire(1, plan, "Eve", "eve@example.com", null, null, DateTime.Today, null));
+        }
+
+        [Fact]
+        public void CreateHire_WithNullPlan_ThrowsArgumentNullException()
+        {
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.CreateHire(1, null, "Frank", "frank@example.com", null, null, DateTime.Today, null));
+        }
+
+        [Fact]
+        public void CreateHire_WithZeroTenantId_ThrowsArgumentOutOfRangeException()
+        {
+            var plan = PublishedPlan(1);
+
+            Should.Throw<ArgumentOutOfRangeException>(() =>
+                _manager.CreateHire(0, plan, "Grace", "grace@example.com", null, null, DateTime.Today, null));
+        }
+
+        [Fact]
+        public void CreateHire_WithMismatchedTenant_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan(tenantId: 99);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.CreateHire(1, plan, "Hal", "hal@example.com", null, null, DateTime.Today, null));
+        }
+
+        [Fact]
+        public void CreateHire_WithDefaultStartDate_ThrowsArgumentOutOfRangeException()
+        {
+            var plan = PublishedPlan();
+
+            Should.Throw<ArgumentOutOfRangeException>(() =>
+                _manager.CreateHire(1, plan, "Ida", "ida@example.com", null, null, default, null));
+        }
+
+        // ─── CreateDraftJourney ────────────────────────────────────────────────────
+
+        [Fact]
+        public void CreateDraftJourney_WithValidInputs_ReturnsJourneyInDraftStatus()
+        {
+            var plan = PublishedPlan();
+            var hire = SeedHire(planId: plan.Id);
+
+            var journey = _manager.CreateDraftJourney(hire, plan);
+
+            journey.ShouldNotBeNull();
+            journey.Status.ShouldBe(JourneyStatus.Draft);
+            journey.HireId.ShouldBe(hire.Id);
+            journey.TenantId.ShouldBe(hire.TenantId);
+        }
+
+        [Fact]
+        public void CreateDraftJourney_WhenHireAlreadyHasJourney_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+            var hire = SeedHire(planId: plan.Id);
+            hire.Journey = DraftJourneyFor(hire);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.CreateDraftJourney(hire, plan));
+        }
+
+        [Fact]
+        public void CreateDraftJourney_WithMismatchedPlan_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+            var hire = SeedHire(); // different plan ID
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.CreateDraftJourney(hire, plan));
+        }
+
+        // ─── ActivateJourney ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void ActivateJourney_WithAtLeastOneTask_TransitionsToActive()
+        {
+            var hire = SeedHire();
+            var journey = DraftJourneyFor(hire);
+            journey.Tasks.Add(SeedJourneyTask(journey));
+
+            _manager.ActivateJourney(hire, journey);
+
+            journey.Status.ShouldBe(JourneyStatus.Active);
+            journey.ActivatedAt.ShouldNotBeNull();
+            hire.Status.ShouldBe(HireLifecycleState.Active);
+            hire.ActivatedAt.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ActivateJourney_WithNoTasks_ThrowsInvalidOperationException()
+        {
+            var hire = SeedHire();
+            var journey = DraftJourneyFor(hire);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.ActivateJourney(hire, journey));
+        }
+
+        [Fact]
+        public void ActivateJourney_OnAlreadyActiveJourney_ThrowsInvalidOperationException()
+        {
+            var hire = SeedHire();
+            var journey = DraftJourneyFor(hire);
+            journey.Tasks.Add(SeedJourneyTask(journey));
+            journey.Status = JourneyStatus.Active;
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.ActivateJourney(hire, journey));
+        }
+
+        // ─── PauseJourney ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public void PauseJourney_OnActiveJourney_TransitionsToPaused()
+        {
+            var hire = SeedHire(status: HireLifecycleState.Active);
+            var journey = DraftJourneyFor(hire);
+            journey.Status = JourneyStatus.Active;
+
+            _manager.PauseJourney(hire, journey);
+
+            journey.Status.ShouldBe(JourneyStatus.Paused);
+            journey.PausedAt.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void PauseJourney_OnDraftJourney_ThrowsInvalidOperationException()
+        {
+            var hire = SeedHire();
+            var journey = DraftJourneyFor(hire);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.PauseJourney(hire, journey));
+        }
+
+        // ─── CompleteJourney ───────────────────────────────────────────────────────
+
+        [Fact]
+        public void CompleteJourney_OnActiveJourney_TransitionsToCompleted()
+        {
+            var hire = SeedHire(status: HireLifecycleState.Active);
+            var journey = DraftJourneyFor(hire);
+            journey.Status = JourneyStatus.Active;
+
+            _manager.CompleteJourney(hire, journey);
+
+            journey.Status.ShouldBe(JourneyStatus.Completed);
+            hire.Status.ShouldBe(HireLifecycleState.Completed);
+            hire.CompletedAt.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void CompleteJourney_OnPausedJourney_TransitionsToCompleted()
+        {
+            var hire = SeedHire(status: HireLifecycleState.Active);
+            var journey = DraftJourneyFor(hire);
+            journey.Status = JourneyStatus.Paused;
+
+            _manager.CompleteJourney(hire, journey);
+
+            journey.Status.ShouldBe(JourneyStatus.Completed);
+        }
+
+        [Fact]
+        public void CompleteJourney_OnDraftJourney_ThrowsInvalidOperationException()
+        {
+            var hire = SeedHire();
+            var journey = DraftJourneyFor(hire);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.CompleteJourney(hire, journey));
+        }
+
+        // ─── ExitHire ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ExitHire_WithNoJourney_MarksHireAsExited()
+        {
+            var hire = SeedHire(status: HireLifecycleState.Active);
+
+            _manager.ExitHire(hire, null);
+
+            hire.Status.ShouldBe(HireLifecycleState.Exited);
+            hire.ExitedAt.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ExitHire_WithActiveJourney_PausesJourney()
+        {
+            var hire = SeedHire(status: HireLifecycleState.Active);
+            var journey = DraftJourneyFor(hire);
+            journey.Status = JourneyStatus.Active;
+
+            _manager.ExitHire(hire, journey);
+
+            hire.Status.ShouldBe(HireLifecycleState.Exited);
+            journey.Status.ShouldBe(JourneyStatus.Paused);
+        }
+
+        [Fact]
+        public void ExitHire_WhenAlreadyExited_ThrowsInvalidOperationException()
+        {
+            var hire = SeedHire(status: HireLifecycleState.Exited);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.ExitHire(hire, null));
+        }
+    }
+}

--- a/aspnet-core/test/JourneyPoint.Tests/Domains/OnboardingPlanManager_Tests.cs
+++ b/aspnet-core/test/JourneyPoint.Tests/Domains/OnboardingPlanManager_Tests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.ObjectModel;
+using JourneyPoint.Domains.OnboardingPlans;
+using Shouldly;
+using Xunit;
+
+namespace JourneyPoint.Tests.Domains
+{
+    public class OnboardingPlanManager_Tests
+    {
+        private readonly OnboardingPlanManager _manager = new();
+
+        // ─── Helpers ───────────────────────────────────────────────────────────────
+
+        private OnboardingPlan CreateDraftPlan(int tenantId = 1) =>
+            _manager.CreatePlan(tenantId, "Onboarding Plan", "A solid plan", "New engineers", 30);
+
+        private static OnboardingPlan PublishedPlan(int tenantId = 1) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                Name = "Published Plan",
+                Description = "Already live",
+                TargetAudience = "All staff",
+                DurationDays = 14,
+                Status = OnboardingPlanStatus.Published,
+                Modules = new Collection<OnboardingModule>()
+            };
+
+        private OnboardingModule CreateModule(int orderIndex = 1) =>
+            _manager.CreateModule("Week 1", "First week tasks", orderIndex);
+
+        private OnboardingTask CreateTask(int orderIndex = 1) =>
+            _manager.CreateTask(
+                "Complete forms",
+                "Fill out all HR forms",
+                OnboardingTaskCategory.Orientation,
+                orderIndex,
+                0,
+                OnboardingTaskAssignmentTarget.Enrolee,
+                OnboardingTaskAcknowledgementRule.Required);
+
+        // ─── CreatePlan ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void CreatePlan_WithValidInputs_ReturnsDraftPlan()
+        {
+            var plan = _manager.CreatePlan(1, "My Plan", "Description", "Engineers", 30);
+
+            plan.ShouldNotBeNull();
+            plan.Name.ShouldBe("My Plan");
+            plan.Description.ShouldBe("Description");
+            plan.TargetAudience.ShouldBe("Engineers");
+            plan.DurationDays.ShouldBe(30);
+            plan.TenantId.ShouldBe(1);
+            plan.Status.ShouldBe(OnboardingPlanStatus.Draft);
+        }
+
+        [Fact]
+        public void CreatePlan_TrimsWhitespaceFromName()
+        {
+            var plan = _manager.CreatePlan(1, "  My Plan  ", "Description", "Engineers", 30);
+
+            plan.Name.ShouldBe("My Plan");
+        }
+
+        [Fact]
+        public void CreatePlan_WithZeroTenantId_ThrowsArgumentOutOfRangeException()
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() =>
+                _manager.CreatePlan(0, "Plan", "Desc", "Audience", 30));
+        }
+
+        [Fact]
+        public void CreatePlan_WithNullName_ThrowsArgumentException()
+        {
+            Should.Throw<ArgumentException>(() =>
+                _manager.CreatePlan(1, null, "Desc", "Audience", 30));
+        }
+
+        [Fact]
+        public void CreatePlan_WithWhitespaceName_ThrowsArgumentException()
+        {
+            Should.Throw<ArgumentException>(() =>
+                _manager.CreatePlan(1, "   ", "Desc", "Audience", 30));
+        }
+
+        [Fact]
+        public void CreatePlan_WithZeroDurationDays_ThrowsException()
+        {
+            Should.Throw<Exception>(() =>
+                _manager.CreatePlan(1, "Plan", "Desc", "Audience", 0));
+        }
+
+        // ─── UpdatePlanDetails ─────────────────────────────────────────────────────
+
+        [Fact]
+        public void UpdatePlanDetails_OnDraftPlan_UpdatesAllFields()
+        {
+            var plan = CreateDraftPlan();
+
+            _manager.UpdatePlanDetails(plan, "Updated Name", "Updated Desc", "Updated Audience", 60);
+
+            plan.Name.ShouldBe("Updated Name");
+            plan.Description.ShouldBe("Updated Desc");
+            plan.TargetAudience.ShouldBe("Updated Audience");
+            plan.DurationDays.ShouldBe(60);
+        }
+
+        [Fact]
+        public void UpdatePlanDetails_OnPublishedPlan_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.UpdatePlanDetails(plan, "New Name", "New Desc", "Audience", 30));
+        }
+
+        [Fact]
+        public void UpdatePlanDetails_WithNullPlan_ThrowsArgumentNullException()
+        {
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.UpdatePlanDetails(null, "Name", "Desc", "Audience", 30));
+        }
+
+        // ─── AddModule ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void AddModule_ToDraftPlan_AddsModuleToCollection()
+        {
+            var plan = CreateDraftPlan();
+            var module = CreateModule(orderIndex: 1);
+
+            _manager.AddModule(plan, module);
+
+            plan.Modules.Count.ShouldBe(1);
+            plan.Modules.ShouldContain(m => m.Name == "Week 1");
+        }
+
+        [Fact]
+        public void AddModule_SetsModuleTenantAndPlanIds()
+        {
+            var plan = CreateDraftPlan(tenantId: 5);
+            var module = CreateModule();
+
+            _manager.AddModule(plan, module);
+
+            module.TenantId.ShouldBe(5);
+            module.OnboardingPlanId.ShouldBe(plan.Id);
+        }
+
+        [Fact]
+        public void AddModule_ToPublishedPlan_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+            var module = CreateModule();
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.AddModule(plan, module));
+        }
+
+        [Fact]
+        public void AddModule_WithDuplicateOrderIndex_ThrowsInvalidOperationException()
+        {
+            var plan = CreateDraftPlan();
+            var moduleA = CreateModule(orderIndex: 1);
+            var moduleB = CreateModule(orderIndex: 1);
+            _manager.AddModule(plan, moduleA);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.AddModule(plan, moduleB));
+        }
+
+        [Fact]
+        public void AddModule_WithNullModule_ThrowsArgumentNullException()
+        {
+            var plan = CreateDraftPlan();
+
+            Should.Throw<ArgumentNullException>(() =>
+                _manager.AddModule(plan, null));
+        }
+
+        // ─── RemoveModule ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public void RemoveModule_FromDraftPlan_RemovesModule()
+        {
+            var plan = CreateDraftPlan();
+            var module = CreateModule();
+            _manager.AddModule(plan, module);
+
+            _manager.RemoveModule(plan, module.Id);
+
+            plan.Modules.Count.ShouldBe(0);
+        }
+
+        [Fact]
+        public void RemoveModule_FromPublishedPlan_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.RemoveModule(plan, Guid.NewGuid()));
+        }
+
+        // ─── AddTask / RemoveTask ──────────────────────────────────────────────────
+
+        [Fact]
+        public void AddTask_ToModule_AddsTaskToModule()
+        {
+            var plan = CreateDraftPlan();
+            var module = CreateModule();
+            _manager.AddModule(plan, module);
+            var task = CreateTask(orderIndex: 1);
+
+            _manager.AddTask(plan, module.Id, task);
+
+            module.Tasks.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void RemoveTask_FromModule_RemovesTask()
+        {
+            var plan = CreateDraftPlan();
+            var module = CreateModule();
+            _manager.AddModule(plan, module);
+            var task = CreateTask();
+            _manager.AddTask(plan, module.Id, task);
+
+            _manager.RemoveTask(plan, module.Id, task.Id);
+
+            module.Tasks.Count.ShouldBe(0);
+        }
+
+        // ─── Publish ───────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Publish_DraftPlanWithModulesAndTasks_TransitionsToPublished()
+        {
+            var plan = CreateDraftPlan();
+            var module = CreateModule();
+            _manager.AddModule(plan, module);
+            _manager.AddTask(plan, module.Id, CreateTask());
+
+            _manager.Publish(plan);
+
+            plan.Status.ShouldBe(OnboardingPlanStatus.Published);
+        }
+
+        [Fact]
+        public void Publish_PlanWithNoModules_ThrowsInvalidOperationException()
+        {
+            var plan = CreateDraftPlan();
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.Publish(plan));
+        }
+
+        [Fact]
+        public void Publish_PlanWithEmptyModule_ThrowsInvalidOperationException()
+        {
+            var plan = CreateDraftPlan();
+            var module = CreateModule();
+            _manager.AddModule(plan, module); // no tasks added
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.Publish(plan));
+        }
+
+        [Fact]
+        public void Publish_AlreadyPublishedPlan_ThrowsInvalidOperationException()
+        {
+            var plan = PublishedPlan();
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.Publish(plan));
+        }
+
+        // ─── Archive ───────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Archive_DraftPlan_TransitionsToArchived()
+        {
+            var plan = CreateDraftPlan();
+
+            _manager.Archive(plan);
+
+            plan.Status.ShouldBe(OnboardingPlanStatus.Archived);
+        }
+
+        [Fact]
+        public void Archive_PublishedPlan_TransitionsToArchived()
+        {
+            var plan = PublishedPlan();
+
+            _manager.Archive(plan);
+
+            plan.Status.ShouldBe(OnboardingPlanStatus.Archived);
+        }
+
+        [Fact]
+        public void Archive_AlreadyArchivedPlan_ThrowsInvalidOperationException()
+        {
+            var plan = CreateDraftPlan();
+            _manager.Archive(plan);
+
+            Should.Throw<InvalidOperationException>(() =>
+                _manager.Archive(plan));
+        }
+    }
+}

--- a/aspnet-core/test/JourneyPoint.Tests/OnboardingPlans/OnboardingPlanAppService_Tests.cs
+++ b/aspnet-core/test/JourneyPoint.Tests/OnboardingPlans/OnboardingPlanAppService_Tests.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Abp.Application.Services.Dto;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+using JourneyPoint.Application.Services.OnboardingPlanService;
+using JourneyPoint.Application.Services.OnboardingPlanService.Dto;
+using JourneyPoint.Domains.OnboardingPlans;
+
+namespace JourneyPoint.Tests.OnboardingPlans
+{
+    public class OnboardingPlanAppService_Tests : JourneyPointTestBase
+    {
+        private readonly IOnboardingPlanAppService _planAppService;
+
+        public OnboardingPlanAppService_Tests()
+        {
+            _planAppService = Resolve<IOnboardingPlanAppService>();
+        }
+
+        // ─── Helpers ───────────────────────────────────────────────────────────────
+
+        private static CreateOnboardingPlanRequest DraftPlanRequest(string name = "Graduate Onboarding") =>
+            new()
+            {
+                Name = name,
+                Description = "A comprehensive 30-day onboarding plan.",
+                TargetAudience = "Software Engineers",
+                DurationDays = 30,
+                Modules = new List<UpsertOnboardingModuleDto>()
+            };
+
+        private static CreateOnboardingPlanRequest DraftPlanWithModulesRequest(string name = "Engineer Onboarding") =>
+            new()
+            {
+                Name = name,
+                Description = "Full plan with modules.",
+                TargetAudience = "Backend Engineers",
+                DurationDays = 14,
+                Modules = new List<UpsertOnboardingModuleDto>
+                {
+                    new()
+                    {
+                        Name = "Week 1",
+                        Description = "Introduction week",
+                        OrderIndex = 1,
+                        Tasks = new List<UpsertOnboardingTaskDto>
+                        {
+                            new()
+                            {
+                                Title = "Complete paperwork",
+                                Description = "Fill in all HR forms",
+                                Category = OnboardingTaskCategory.Orientation,
+                                OrderIndex = 1,
+                                DueDayOffset = 1,
+                                AssignmentTarget = OnboardingTaskAssignmentTarget.Enrolee,
+                                AcknowledgementRule = OnboardingTaskAcknowledgementRule.Required
+                            }
+                        }
+                    }
+                }
+            };
+
+        private async Task<OnboardingPlanDetailDto> CreateAndPublishPlanAsync(string name = "Published Plan")
+        {
+            var plan = await _planAppService.CreateAsync(DraftPlanWithModulesRequest(name));
+            return await _planAppService.PublishAsync(new EntityDto<Guid>(plan.Id));
+        }
+
+        // ─── GetPlansAsync ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task GetPlansAsync_WithNoFilter_ReturnsAllTenantPlans()
+        {
+            await _planAppService.CreateAsync(DraftPlanRequest("Plan A"));
+            await _planAppService.CreateAsync(DraftPlanRequest("Plan B"));
+
+            var result = await _planAppService.GetPlansAsync(new GetOnboardingPlansInput { MaxResultCount = 50 });
+
+            result.TotalCount.ShouldBeGreaterThanOrEqualTo(2);
+            result.Items.ShouldContain(p => p.Name == "Plan A");
+            result.Items.ShouldContain(p => p.Name == "Plan B");
+        }
+
+        [Fact]
+        public async Task GetPlansAsync_WithKeywordFilter_ReturnsMatchingPlans()
+        {
+            await _planAppService.CreateAsync(DraftPlanRequest("Alpha Onboarding"));
+            await _planAppService.CreateAsync(DraftPlanRequest("Beta Onboarding"));
+
+            var result = await _planAppService.GetPlansAsync(new GetOnboardingPlansInput
+            {
+                Keyword = "Alpha",
+                MaxResultCount = 50
+            });
+
+            result.Items.ShouldContain(p => p.Name == "Alpha Onboarding");
+            result.Items.ShouldNotContain(p => p.Name == "Beta Onboarding");
+        }
+
+        [Fact]
+        public async Task GetPlansAsync_WithStatusFilter_ReturnsOnlyMatchingStatus()
+        {
+            await _planAppService.CreateAsync(DraftPlanRequest("Status Filter Draft"));
+
+            var result = await _planAppService.GetPlansAsync(new GetOnboardingPlansInput
+            {
+                Status = OnboardingPlanStatus.Draft,
+                MaxResultCount = 50
+            });
+
+            result.Items.ShouldAllBe(p => p.Status == OnboardingPlanStatus.Draft);
+        }
+
+        [Fact]
+        public async Task GetPlansAsync_ReturnsModuleAndTaskCounts()
+        {
+            await _planAppService.CreateAsync(DraftPlanWithModulesRequest("Counted Plan"));
+
+            var result = await _planAppService.GetPlansAsync(new GetOnboardingPlansInput
+            {
+                Keyword = "Counted Plan",
+                MaxResultCount = 10
+            });
+
+            var item = result.Items.ShouldHaveSingleItem();
+            item.ModuleCount.ShouldBe(1);
+            item.TaskCount.ShouldBe(1);
+        }
+
+        // ─── GetDetailAsync ────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task GetDetailAsync_ExistingPlan_ReturnsPlanWithModulesAndTasks()
+        {
+            var created = await _planAppService.CreateAsync(DraftPlanWithModulesRequest("Detail Plan"));
+
+            var detail = await _planAppService.GetDetailAsync(new EntityDto<Guid>(created.Id));
+
+            detail.ShouldNotBeNull();
+            detail.Name.ShouldBe("Detail Plan");
+            detail.Modules.Count.ShouldBe(1);
+            detail.Modules[0].Tasks.Count.ShouldBe(1);
+        }
+
+        // ─── CreateAsync ───────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task CreateAsync_WithValidInput_PersistsPlanInDatabase()
+        {
+            var request = DraftPlanRequest("DB Persisted Plan");
+
+            var created = await _planAppService.CreateAsync(request);
+
+            await UsingDbContextAsync(async context =>
+            {
+                var plan = await context.OnboardingPlans.FirstOrDefaultAsync(p => p.Id == created.Id);
+                plan.ShouldNotBeNull();
+                plan.Name.ShouldBe("DB Persisted Plan");
+                plan.Status.ShouldBe(OnboardingPlanStatus.Draft);
+            });
+        }
+
+        [Fact]
+        public async Task CreateAsync_WithModulesAndTasks_PersistsFullStructure()
+        {
+            var request = DraftPlanWithModulesRequest("Structured Plan");
+
+            var created = await _planAppService.CreateAsync(request);
+
+            created.Modules.Count.ShouldBe(1);
+            created.Modules[0].Name.ShouldBe("Week 1");
+            created.Modules[0].Tasks.Count.ShouldBe(1);
+            created.Modules[0].Tasks[0].Title.ShouldBe("Complete paperwork");
+        }
+
+        [Fact]
+        public async Task CreateAsync_ReturnsDraftStatus()
+        {
+            var created = await _planAppService.CreateAsync(DraftPlanRequest());
+
+            created.Status.ShouldBe(OnboardingPlanStatus.Draft);
+        }
+
+        // ─── PublishAsync ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task PublishAsync_DraftPlanWithModulesAndTasks_TransitionsToPublished()
+        {
+            var plan = await _planAppService.CreateAsync(DraftPlanWithModulesRequest("To Publish"));
+
+            var published = await _planAppService.PublishAsync(new EntityDto<Guid>(plan.Id));
+
+            published.Status.ShouldBe(OnboardingPlanStatus.Published);
+        }
+
+        [Fact]
+        public async Task PublishAsync_PersistsPublishedStatusInDatabase()
+        {
+            var plan = await _planAppService.CreateAsync(DraftPlanWithModulesRequest("Persist Published"));
+            await _planAppService.PublishAsync(new EntityDto<Guid>(plan.Id));
+
+            await UsingDbContextAsync(async context =>
+            {
+                var persisted = await context.OnboardingPlans.FindAsync(plan.Id);
+                persisted.Status.ShouldBe(OnboardingPlanStatus.Published);
+            });
+        }
+
+        // ─── ArchiveAsync ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task ArchiveAsync_PublishedPlan_TransitionsToArchived()
+        {
+            var published = await CreateAndPublishPlanAsync("To Archive");
+
+            var archived = await _planAppService.ArchiveAsync(new EntityDto<Guid>(published.Id));
+
+            archived.Status.ShouldBe(OnboardingPlanStatus.Archived);
+        }
+
+        [Fact]
+        public async Task ArchiveAsync_DraftPlan_TransitionsToArchived()
+        {
+            var plan = await _planAppService.CreateAsync(DraftPlanRequest("Draft to Archive"));
+
+            var archived = await _planAppService.ArchiveAsync(new EntityDto<Guid>(plan.Id));
+
+            archived.Status.ShouldBe(OnboardingPlanStatus.Archived);
+        }
+
+        // ─── CloneAsync ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task CloneAsync_PublishedPlan_CreatesDraftCopyWithSameStructure()
+        {
+            var source = await CreateAndPublishPlanAsync("Source Plan");
+
+            var clone = await _planAppService.CloneAsync(new CloneOnboardingPlanRequest
+            {
+                SourcePlanId = source.Id
+            });
+
+            clone.ShouldNotBeNull();
+            clone.Id.ShouldNotBe(source.Id);
+            clone.Status.ShouldBe(OnboardingPlanStatus.Draft);
+            clone.Name.ShouldBe("Source Plan Copy");
+            clone.Modules.Count.ShouldBe(source.Modules.Count);
+        }
+
+        [Fact]
+        public async Task CloneAsync_WithCustomName_UsesProvidedName()
+        {
+            var source = await CreateAndPublishPlanAsync("Original");
+
+            var clone = await _planAppService.CloneAsync(new CloneOnboardingPlanRequest
+            {
+                SourcePlanId = source.Id,
+                Name = "My Custom Clone"
+            });
+
+            clone.Name.ShouldBe("My Custom Clone");
+        }
+
+        [Fact]
+        public async Task CloneAsync_PreservesModulesAndTasksFromSource()
+        {
+            var source = await CreateAndPublishPlanAsync("Clone Source");
+
+            var clone = await _planAppService.CloneAsync(new CloneOnboardingPlanRequest
+            {
+                SourcePlanId = source.Id
+            });
+
+            clone.Modules.Count.ShouldBe(1);
+            clone.Modules[0].Name.ShouldBe("Week 1");
+            clone.Modules[0].Tasks.Count.ShouldBe(1);
+            clone.Modules[0].Tasks[0].Title.ShouldBe("Complete paperwork");
+        }
+
+        [Fact]
+        public async Task CloneAsync_PersistsCloneInDatabase()
+        {
+            var source = await CreateAndPublishPlanAsync("DB Clone Source");
+
+            var clone = await _planAppService.CloneAsync(new CloneOnboardingPlanRequest
+            {
+                SourcePlanId = source.Id
+            });
+
+            await UsingDbContextAsync(async context =>
+            {
+                var persisted = await context.OnboardingPlans.FindAsync(clone.Id);
+                persisted.ShouldNotBeNull();
+                persisted.Status.ShouldBe(OnboardingPlanStatus.Draft);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Linking Issues: #83

This pull request introduces comprehensive unit tests for the engagement scoring and management domain logic, as well as a new launch configuration for local development. The added tests cover validation, calculation, and state transitions for engagement scores and at-risk flags, ensuring that the business logic is robust and behaves as expected.

Unit tests for engagement logic:

* Added `EngagementScoreService_Tests` to verify all aspects of engagement score calculation, including input validation, completion rate, recency, overdue penalties, composite scoring, classification, and timestamp preservation.
* Added `EngagementManager_Tests` to cover snapshot creation, at-risk flag raising and state transitions (acknowledge, resolve, auto-resolve), and validation of business rules for engagement management.

Development tooling:

* Introduced `.claude/launch.json` with launch configurations for the frontend, API, and migrator services to simplify local development and debugging.