### PR TITLE
Remove welcome notification UI and background send

### DIFF
--- a/aspnet-core/src/JourneyPoint.Application/Services/HireService/HireAppService.cs
+++ b/aspnet-core/src/JourneyPoint.Application/Services/HireService/HireAppService.cs
@@ -106,8 +106,6 @@ namespace JourneyPoint.Application.Services.HireService
             await _hireRepository.InsertAsync(hire);
             await CurrentUnitOfWork.SaveChangesAsync();
 
-            _ = SendWelcomeNotificationInBackgroundAsync(hire.Id, platformUser.Id, temporaryPassword, tenantId);
-
             return MapToResultDto(hire);
         }
 

--- a/journeypoint/components/hires/HireCard.tsx
+++ b/journeypoint/components/hires/HireCard.tsx
@@ -5,8 +5,6 @@ import { Button, Card, Space, Tag, Typography } from "antd";
 import {
     HIRE_STATUS_LABELS,
     HIRE_STATUS_TAG_COLORS,
-    WELCOME_STATUS_LABELS,
-    WELCOME_STATUS_TAG_COLORS,
 } from "@/constants/hire/list";
 import {
     JOURNEY_STATUS_LABELS,
@@ -37,10 +35,6 @@ const HireCard: React.FC<HireCardProps> = ({ hire, onOpenDetail, onOpenJourney }
                         <span><Text type="secondary">Status:</Text>{" "}
                             <Tag color={HIRE_STATUS_TAG_COLORS[hire.status]}>
                                 {HIRE_STATUS_LABELS[hire.status]}
-                            </Tag></span>
-                        <span><Text type="secondary">Welcome:</Text>{" "}
-                            <Tag color={WELCOME_STATUS_TAG_COLORS[hire.welcomeNotificationStatus]}>
-                                {WELCOME_STATUS_LABELS[hire.welcomeNotificationStatus]}
                             </Tag></span>
                         {hire.journeyStatus ? (
                             <span><Text type="secondary">Journey:</Text>{" "}

--- a/journeypoint/components/hires/HireDetailView.tsx
+++ b/journeypoint/components/hires/HireDetailView.tsx
@@ -24,8 +24,6 @@ import { ArrowRightOutlined, ReloadOutlined, WarningOutlined } from "@ant-design
 import {
     HIRE_STATUS_LABELS,
     HIRE_STATUS_TAG_COLORS,
-    WELCOME_STATUS_LABELS,
-    WELCOME_STATUS_TAG_COLORS,
 } from "@/constants/hire/list";
 import {
     JOURNEY_STATUS_LABELS,
@@ -143,12 +141,6 @@ const HireDetailView: React.FC<HireDetailViewProps> = ({ hireId }) => {
                         </Descriptions.Item>
                         <Descriptions.Item label="Manager">
                             {selectedHire.managerDisplayName || "No manager assigned"}
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Welcome sent">
-                            {formatDisplayDateTime(selectedHire.welcomeNotificationSentAt)}
-                        </Descriptions.Item>
-                        <Descriptions.Item label="Last attempted">
-                            {formatDisplayDateTime(selectedHire.welcomeNotificationLastAttemptedAt)}
                         </Descriptions.Item>
                     </Descriptions>
                 </Card>
@@ -271,10 +263,6 @@ const HireDetailView: React.FC<HireDetailViewProps> = ({ hireId }) => {
                         <Tag color={HIRE_STATUS_TAG_COLORS[selectedHire.status]}>
                             {HIRE_STATUS_LABELS[selectedHire.status]}
                         </Tag></span>
-                        <span><Text type="secondary">Welcome:</Text>{" "}
-                        <Tag color={WELCOME_STATUS_TAG_COLORS[selectedHire.welcomeNotificationStatus]}>
-                            {WELCOME_STATUS_LABELS[selectedHire.welcomeNotificationStatus]}
-                        </Tag></span>
                         {selectedHire.journey ? (
                             <span><Text type="secondary">Journey:</Text>{" "}
                             <Tag color={JOURNEY_STATUS_TAG_COLORS[selectedHire.journey.status]}>
@@ -304,14 +292,6 @@ const HireDetailView: React.FC<HireDetailViewProps> = ({ hireId }) => {
                     </Button>
                 </Space>
             </div>
-
-            {selectedHire.welcomeNotificationFailureReason ? (
-                <Alert
-                    type="warning"
-                    title="Welcome notification needs HR Facilitator follow-up."
-                    description={selectedHire.welcomeNotificationFailureReason}
-                />
-            ) : null}
 
             <Tabs
                 defaultActiveKey="overview"

--- a/journeypoint/components/hires/HireListView.tsx
+++ b/journeypoint/components/hires/HireListView.tsx
@@ -66,7 +66,6 @@ const HireListView: React.FC<HireListViewProps> = () => {
     const [query, setQuery] = useState<HireListQueryState>(DEFAULT_HIRE_LIST_QUERY_STATE);
     const hiresInView = hires ?? [];
     const hiresWithoutJourney = hiresInView.filter((hire) => !hire.journeyId).length;
-    const failedWelcomeCount = hiresInView.filter((hire) => hire.welcomeNotificationStatus === 2).length;
 
     const loadHires = useEffectEvent(async (): Promise<void> => {
         await getHires(buildHireListRequest(query));
@@ -128,11 +127,7 @@ const HireListView: React.FC<HireListViewProps> = () => {
         setIsCreateModalOpen(false);
         await refreshHires();
 
-        if (result.welcomeNotificationFailureReason) {
-            messageApi.warning("Hire created, but the welcome notification needs follow-up.");
-        } else {
-            messageApi.success("Hire enrolled successfully.");
-        }
+        messageApi.success("Hire enrolled successfully.");
 
         startTransition(() => {
             router.push(buildFacilitatorHireRoute(result.id));
@@ -211,7 +206,6 @@ const HireListView: React.FC<HireListViewProps> = () => {
                             <Statistic title="Total hires" value={totalCount ?? 0} />
                             <Statistic title="In current page" value={hiresInView.length} />
                             <Statistic title="Without journey" value={hiresWithoutJourney} />
-                            <Statistic title="Welcome follow-up" value={failedWelcomeCount} />
                         </div>
 
                         <div className={styles.sidebarActions}>


### PR DESCRIPTION
Remove backend call to send welcome notifications and strip related UI elements and counts. Deleted the SendWelcomeNotificationInBackgroundAsync invocation in HireAppService and removed welcome status imports, tags, detail fields, failure alert, follow-up statistic, and conditional warning message from HireCard.tsx, HireDetailView.tsx, and HireListView.tsx. Simplifies hire creation flow by always showing a success message and removes UI references to the deprecated welcome notification feature.